### PR TITLE
Print filename for compose results

### DIFF
--- a/cmd/composer-cli/compose/results.go
+++ b/cmd/composer-cli/compose/results.go
@@ -5,6 +5,7 @@
 package compose
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -48,6 +49,8 @@ func getResults(cmd *cobra.Command, args []string) (rcErr error) {
 	if err != nil {
 		return root.ExecutionError(cmd, "problem moving file: %s", err)
 	}
+
+	fmt.Println(fn)
 
 	return nil
 }

--- a/cmd/composer-cli/compose/results_test.go
+++ b/cmd/composer-cli/compose/results_test.go
@@ -59,7 +59,7 @@ And should do the job.`
 	assert.Equal(t, cmd, resultsCmd)
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
-	assert.Equal(t, []byte(""), stdout)
+	assert.Contains(t, string(stdout), "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7.tar")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)


### PR DESCRIPTION
In the previous version of composer-cli it printed the download
progress. This isn't currently possible, so just print the filename when
it is finished.

Fixes #15