### PR TITLE
Makefile: Add scratch-srpm and scratch-rpm targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,9 @@ $(RPM_TARBALL): archive sign
 	mkdir -p $(CURDIR)/rpmbuild/SOURCES
 	cp weldr-client-$(VERSION).tar.gz* gpg-$(GPGKEY).key rpmbuild/SOURCES/
 
+builddep: $(RPM_SPECFILE)
+	dnf builddep -y --spec -D 'with 1' $(RPM_SPECFILE)
+
 srpm: $(RPM_SPECFILE) $(RPM_TARBALL)
 	rpmbuild -bs \
 		--define "_topdir $(CURDIR)/rpmbuild" \
@@ -87,11 +90,30 @@ srpm: $(RPM_SPECFILE) $(RPM_TARBALL)
 		$(RPM_SPECFILE)
 
 rpm: $(RPM_SPECFILE) $(RPM_TARBALL)
-	dnf builddep -y --spec -D 'with 1' $(RPM_SPECFILE)
 	rpmbuild -bb \
 		--define "_topdir $(CURDIR)/rpmbuild" \
 		--define "commit $(VERSION)" \
 		--with tests \
+		$(RPM_SPECFILE)
+
+scratch-srpm: $(RPM_SPECFILE) archive
+	mkdir -p $(CURDIR)/rpmbuild/SOURCES
+	cp weldr-client-$(VERSION).tar.gz* rpmbuild/SOURCES/
+	rpmbuild -bs \
+		--define "_topdir $(CURDIR)/rpmbuild" \
+		--define "commit $(VERSION)" \
+		--with tests \
+		--without signed \
+		$(RPM_SPECFILE)
+
+scratch-rpm: $(RPM_SPECFILE) archive
+	mkdir -p $(CURDIR)/rpmbuild/SOURCES
+	cp weldr-client-$(VERSION).tar.gz* rpmbuild/SOURCES/
+	rpmbuild -bb \
+		--define "_topdir $(CURDIR)/rpmbuild" \
+		--define "commit $(VERSION)" \
+		--with tests \
+		--without signed \
 		$(RPM_SPECFILE)
 
 

--- a/weldr-client.spec.in
+++ b/weldr-client.spec.in
@@ -1,5 +1,7 @@
 # Pass --with tests to rpmbuild to build composer-cli-tests
 %bcond_with tests
+# Pass --without signed to skip gpg signed tar.gz (DO NOT DO THAT IN PRODUCTION)
+%bcond_without signed
 
 %global goipath         github.com/osbuild/weldr-client
 
@@ -11,8 +13,10 @@ License:   ASL 2.0
 Summary:   Command line utility to control osbuild-composer
 Url:       %{gourl}
 Source0:   https://github.com/osbuild/weldr-client/releases/download/v%{version}/%{name}-%{version}.tar.gz
+%if %{with signed}
 Source1:   https://github.com/osbuild/weldr-client/releases/download/v%{version}/%{name}-%{version}.tar.gz.asc
 Source2:   https://keys.openpgp.org/vks/v1/by-fingerprint/%%GPGKEY%%#/gpg-%%GPGKEY%%.key
+%endif
 
 Obsoletes: composer-cli < 35.0
 Provides: composer-cli = %{version}-%{release}
@@ -37,7 +41,9 @@ BuildRequires: gnupg2
 Command line utility to control osbuild-composer
 
 %prep
+%if %{with signed}
 %{gpgverify} --keyring='%{SOURCE2}' --signature='%{SOURCE1}' --data='%{SOURCE0}'
+%endif
 %if 0%{?rhel}
 %forgeautosetup -p1
 %else


### PR DESCRIPTION
Make it easier to build rpms for testing and development. These targets
skip the gpg signature check so DO NOT USE IN PRODUCTION

Also move the rpm builddep to a makefile target instead of requiring
sudo every time you run make with rpm or scratch-rpm