### PR TITLE
tests: Fix integration tests

### DIFF
--- a/weldr/compose_test.go
+++ b/weldr/compose_test.go
@@ -30,7 +30,7 @@ func TestGetComposeTypes(t *testing.T) {
 	require.Nil(t, err)
 	require.Nil(t, r)
 	require.NotNil(t, types)
-	assert.Equal(t, 6, len(types))
+	assert.GreaterOrEqual(t, len(types), 6)
 	assert.Contains(t, types, "openstack")
 }
 
@@ -44,7 +44,7 @@ func TestGetComposeTypesDistro(t *testing.T) {
 	require.Nil(t, err)
 	require.Nil(t, r)
 	require.NotNil(t, types)
-	assert.Equal(t, 6, len(types))
+	assert.GreaterOrEqual(t, len(types), 6)
 	assert.Contains(t, types, "openstack")
 }
 
@@ -141,7 +141,7 @@ func TestStartComposeBadType(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, r)
 	assert.False(t, r.Status)
-	assert.Equal(t, APIErrorMsg{"UnknownComposeType", "Unknown compose type for architecture: punchcard"}, r.Errors[0])
+	assert.Equal(t, APIErrorMsg{"ComposeError", "Failed to get compose type \"punchcard\": invalid image type: punchcard"}, r.Errors[0])
 }
 
 func TestStartComposeBadDepsolve(t *testing.T) {

--- a/weldr/sources_test.go
+++ b/weldr/sources_test.go
@@ -7,6 +7,7 @@
 package weldr
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +41,7 @@ func TestGetSourcesJSON(t *testing.T) {
 	assert.Equal(t, names[0], id)
 	sourceType, ok := sources[names[0]].(map[string]interface{})["type"].(string)
 	require.True(t, ok)
-	assert.Equal(t, "yum-metalink", sourceType)
+	assert.True(t, strings.HasPrefix(sourceType, "yum-"))
 }
 
 func TestGetSourcesJSONError(t *testing.T) {


### PR DESCRIPTION
osbuild-composer v31 returns a more detailed error for
TestStartComposeBadType, so that has been changed.

The number of image types returned depends on the distribution being
used, so change to looking for >= 6 of them.

The source type depends on the first repo in the list, so it could be
any of the supported types. They all start with "yum-" so change the
test to look for that instead.