### PR TITLE
Fix error handling with --json

### DIFF
--- a/cmd/composer-cli/blueprints/changes.go
+++ b/cmd/composer-cli/blueprints/changes.go
@@ -6,7 +6,6 @@ package blueprints
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -33,14 +32,8 @@ func changes(cmd *cobra.Command, args []string) (rcErr error) {
 	if err != nil {
 		return root.ExecutionError(cmd, "Changes Error: %s", err)
 	}
-	if root.JSONOutput {
-		return nil
-	}
 	if len(resp) > 0 {
-		for _, r := range resp {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", r)
-		}
-		rcErr = root.ExecutionError(cmd, "")
+		rcErr = root.ExecutionErrors(cmd, resp)
 	}
 	for _, bp := range blueprints {
 		fmt.Println(bp.Name)

--- a/cmd/composer-cli/blueprints/changes_test.go
+++ b/cmd/composer-cli/blueprints/changes_test.go
@@ -60,7 +60,7 @@ func TestCmdBlueprintsChanges(t *testing.T) {
 	assert.Contains(t, string(stdout), "reverted to commit f48b415828fa7179acd17b1f1b69e11c2c3fcd17")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
-	assert.Contains(t, string(stderr), "ERROR: {UnknownBlueprint no-bp-test}")
+	assert.Contains(t, string(stderr), "ERROR: UnknownBlueprint: no-bp-test")
 	assert.Equal(t, "GET", mc.Req.Method)
 	assert.Equal(t, "/api/v1/blueprints/changes/cli-test-bp-1,test-no-bp", mc.Req.URL.Path)
 }

--- a/cmd/composer-cli/blueprints/changes_test.go
+++ b/cmd/composer-cli/blueprints/changes_test.go
@@ -31,7 +31,106 @@ func TestCmdBlueprintsChanges(t *testing.T) {
 		 "revision": 3,"timestamp": "2021-02-04T14:48:08Z"}
 		],
 	"name": "cli-test-bp-1",
-	"total": 2}], 
+	"total": 2}],
+ "errors": [],
+ "limit": %d,
+ "offset": 0}`
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		jsonResponse := fmt.Sprintf(json, limit)
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("blueprints", "changes", "cli-test-bp-1")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, changesCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.NotContains(t, string(stdout), "{")
+	assert.Contains(t, string(stdout), "cli-test-bp-1")
+	assert.Contains(t, string(stdout), "reverted to commit f48b415828fa7179acd17b1f1b69e11c2c3fcd17")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, "", string(stderr))
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/changes/cli-test-bp-1", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsChangesJSON(t *testing.T) {
+	// Test the "blueprints changes" command with --json
+	json := `
+{"blueprints": [
+	{"changes":[
+		{"commit": "9d519a60b9006f8510c2c6b1a417f7807546bb62",
+		 "message": "cli-test-bp-1.toml reverted to commit f48b415828fa7179acd17b1f1b69e11c2c3fcd17",
+		 "revision": null,"timestamp": "2021-02-08T15:44:35Z"},
+		{"commit": "add3b49eab30eb28afccd5cb76ce0f4e2be18a00",
+		 "message": "Recipe cli-test-bp-1, version 0.0.1 saved.",
+		 "revision": 3,"timestamp": "2021-02-04T14:48:08Z"}
+		],
+	"name": "cli-test-bp-1",
+	"total": 2}],
+ "errors": [],
+ "limit": %d,
+ "offset": 0}`
+
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		jsonResponse := fmt.Sprintf(json, limit)
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "changes", "cli-test-bp-1")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, changesCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
+	assert.Contains(t, string(stdout), "\"message\": \"cli-test-bp-1.toml reverted to commit f48b415828fa7179acd17b1f1b69e11c2c3fcd17\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/changes/cli-test-bp-1?limit=0\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, "", string(stderr))
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/changes/cli-test-bp-1", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsChangesUnknown(t *testing.T) {
+	// Test the "blueprints changes" command with known and unknown blueprints
+	json := `
+{"blueprints": [
+	{"changes":[
+		{"commit": "9d519a60b9006f8510c2c6b1a417f7807546bb62",
+		 "message": "cli-test-bp-1.toml reverted to commit f48b415828fa7179acd17b1f1b69e11c2c3fcd17",
+		 "revision": null,"timestamp": "2021-02-08T15:44:35Z"},
+		{"commit": "add3b49eab30eb28afccd5cb76ce0f4e2be18a00",
+		 "message": "Recipe cli-test-bp-1, version 0.0.1 saved.",
+		 "revision": 3,"timestamp": "2021-02-04T14:48:08Z"}
+		],
+	"name": "cli-test-bp-1",
+	"total": 2}],
  "errors": [{"id": "UnknownBlueprint","msg": "no-bp-test"}],
  "limit": %d,
  "offset": 0}`
@@ -48,6 +147,7 @@ func TestCmdBlueprintsChanges(t *testing.T) {
 	})
 
 	cmd, out, err := root.ExecuteTest("blueprints", "changes", "cli-test-bp-1,test-no-bp")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -56,11 +156,64 @@ func TestCmdBlueprintsChanges(t *testing.T) {
 	assert.Equal(t, cmd, changesCmd)
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
+	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "cli-test-bp-1")
 	assert.Contains(t, string(stdout), "reverted to commit f48b415828fa7179acd17b1f1b69e11c2c3fcd17")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "ERROR: UnknownBlueprint: no-bp-test")
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/changes/cli-test-bp-1,test-no-bp", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsChangesJSONUnknown(t *testing.T) {
+	// Test the "blueprints changes" command with known and unknown blueprints
+	json := `
+{"blueprints": [
+	{"changes":[
+		{"commit": "9d519a60b9006f8510c2c6b1a417f7807546bb62",
+		 "message": "cli-test-bp-1.toml reverted to commit f48b415828fa7179acd17b1f1b69e11c2c3fcd17",
+		 "revision": null,"timestamp": "2021-02-08T15:44:35Z"},
+		{"commit": "add3b49eab30eb28afccd5cb76ce0f4e2be18a00",
+		 "message": "Recipe cli-test-bp-1, version 0.0.1 saved.",
+		 "revision": 3,"timestamp": "2021-02-04T14:48:08Z"}
+		],
+	"name": "cli-test-bp-1",
+	"total": 2}],
+ "errors": [{"id": "UnknownBlueprint","msg": "no-bp-test"}],
+ "limit": %d,
+ "offset": 0}`
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		jsonResponse := fmt.Sprintf(json, limit)
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse))),
+		}, nil
+	})
+
+	// Rerun with JSON output
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "changes", "cli-test-bp-1,test-no-bp")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, changesCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
+	assert.Contains(t, string(stdout), "\"message\": \"cli-test-bp-1.toml reverted to commit f48b415828fa7179acd17b1f1b69e11c2c3fcd17\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/changes/cli-test-bp-1,test-no-bp?limit=0\"")
+	assert.Contains(t, string(stdout), "\"id\": \"UnknownBlueprint\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"no-bp-test\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, "", string(stderr))
 	assert.Equal(t, "GET", mc.Req.Method)
 	assert.Equal(t, "/api/v1/blueprints/changes/cli-test-bp-1,test-no-bp", mc.Req.URL.Path)
 }

--- a/cmd/composer-cli/blueprints/delete.go
+++ b/cmd/composer-cli/blueprints/delete.go
@@ -29,12 +29,8 @@ func delete(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return root.ExecutionError(cmd, "Delete Error: %s", err)
 	}
-	if root.JSONOutput {
-		return nil
-	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "Delete Error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
-
 	return nil
 }

--- a/cmd/composer-cli/blueprints/delete_test.go
+++ b/cmd/composer-cli/blueprints/delete_test.go
@@ -28,6 +28,7 @@ func TestCmdBlueprintsDelete(t *testing.T) {
 	})
 
 	cmd, out, err := root.ExecuteTest("blueprints", "delete", "cli-test-bp-1")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -37,6 +38,36 @@ func TestCmdBlueprintsDelete(t *testing.T) {
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "DELETE", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/delete/cli-test-bp-1", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsDeleteJSON(t *testing.T) {
+	// Test the "blueprints delete" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{"status": true}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "delete", "cli-test-bp-1")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, deleteCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": true")
+	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/delete/cli-test-bp-1\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -61,6 +92,7 @@ func TestCmdBlueprintsDeleteUnknown(t *testing.T) {
 	})
 
 	cmd, out, err := root.ExecuteTest("blueprints", "delete", "foo-bp-1")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -70,6 +102,42 @@ func TestCmdBlueprintsDeleteUnknown(t *testing.T) {
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "DELETE", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/delete/foo-bp-1", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsDeleteJSONUnknown(t *testing.T) {
+	// Test the "blueprints delete" command with an unknown blueprint
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+"errors": [{
+	"id": "BlueprintsError",
+	"msg": "Unknown blueprint: foo-bp-1"
+	}],
+"status": false                                        
+}`
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "delete", "foo-bp-1")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, deleteCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"id\": \"BlueprintsError\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"Unknown blueprint: foo-bp-1\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/delete/foo-bp-1\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)

--- a/cmd/composer-cli/blueprints/depsolve.go
+++ b/cmd/composer-cli/blueprints/depsolve.go
@@ -58,14 +58,8 @@ func depsolve(cmd *cobra.Command, args []string) (rcErr error) {
 	if err != nil {
 		return root.ExecutionError(cmd, "Depsolve Error: %s", err)
 	}
-	if root.JSONOutput {
-		return nil
-	}
 	if len(errors) > 0 {
-		for _, e := range errors {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", e.String())
-		}
-		rcErr = root.ExecutionError(cmd, "")
+		rcErr = root.ExecutionErrors(cmd, errors)
 	}
 
 	for _, bp := range bps {

--- a/cmd/composer-cli/blueprints/depsolve_test.go
+++ b/cmd/composer-cli/blueprints/depsolve_test.go
@@ -69,6 +69,7 @@ func TestCmdBlueprintsDepsolve(t *testing.T) {
 	})
 
 	cmd, out, err := root.ExecuteTest("blueprints", "depsolve", "cli-test-bp-1,test-no-bp")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
 	assert.Equal(t, root.ExecutionError(cmd, ""), err)
@@ -78,6 +79,7 @@ func TestCmdBlueprintsDepsolve(t *testing.T) {
 	assert.Equal(t, cmd, depsolveCmd)
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
+	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "cli-test-bp-1")
 	assert.Contains(t, string(stdout), "acl-2.2.53-9.fc33.x86_64")
 	stderr, err := ioutil.ReadAll(out.Stderr)
@@ -85,4 +87,188 @@ func TestCmdBlueprintsDepsolve(t *testing.T) {
 	assert.Contains(t, string(stderr), "UnknownBlueprint: test-no-bp: blueprint not found")
 	assert.Equal(t, "GET", mc.Req.Method)
 	assert.Equal(t, "/api/v1/blueprints/depsolve/cli-test-bp-1,test-no-bp", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsDepsolveJSON(t *testing.T) {
+	// Test the "blueprints depsolve" command
+	json := `{
+    "blueprints": [
+        {
+            "blueprint": {
+                "description": "composer-cli blueprint test 1",
+                "name": "cli-test-bp-1",
+                "packages": [
+                    {
+                        "name": "bash",
+                        "version": "*"
+                    }
+                ],
+                "version": "0.0.1"
+            },
+            "dependencies": [
+                {
+                    "arch": "x86_64",
+                    "check_gpg": true,
+                    "checksum": "sha256:92c1615d385b32088f78a6574a2bf89a6bb29d9858abdd71471ef5113ef0831f",
+                    "epoch": 0,
+                    "name": "acl",
+                    "release": "9.fc33",
+                    "remote_location": "http://mirror.web-ster.com/fedora/releases/33/Everything/x86_64/os/Packages/a/acl-2.2.53-9.fc33.x86_64.rpm",
+                    "version": "2.2.53"
+                },
+                {
+                    "arch": "x86_64",
+                    "check_gpg": true,
+                    "checksum": "sha256:2200dd65dff57b773532153d3626ecb5914bd7826c42c689ca34be3f60ac3fe2",
+                    "epoch": 0,
+                    "name": "alternatives",
+                    "release": "3.fc33",
+                    "remote_location": "http://mirror.web-ster.com/fedora/releases/33/Everything/x86_64/os/Packages/a/alternatives-1.14-3.fc33.x86_64.rpm",
+                    "version": "1.14"
+                }
+			]
+		}],
+    "errors": [
+        {
+            "id": "UnknownBlueprint",
+            "msg": "test-no-bp: blueprint not found"
+        }
+    ]}`
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "depsolve", "cli-test-bp-1,test-no-bp")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, depsolveCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
+	assert.Contains(t, string(stdout), "\"version\": \"2.2.53\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/depsolve/cli-test-bp-1,test-no-bp\"")
+	assert.Contains(t, string(stdout), "\"id\": \"UnknownBlueprint\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"test-no-bp: blueprint not found\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stderr), "")
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/depsolve/cli-test-bp-1,test-no-bp", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsBadDepsolve(t *testing.T) {
+	// Test the "blueprints depsolve" command with missing package
+	json := `{
+    "blueprints": [
+        {
+            "blueprint": {
+                "description": "composer-cli blueprint test 1",
+                "name": "cli-test-bp-1",
+                "packages": [
+                    {
+                        "name": "bash",
+                        "version": "*"
+                    },
+                    {
+                        "name": "themissing",
+                        "version": "*"
+                    }
+                ],
+                "version": "0.0.1"
+            }
+		}],
+    "errors": [
+        {
+            "id": "BlueprintsError",
+            "msg": "cli-test-bp-1: DNF error occured: MarkingErrors: Error occurred when marking packages for installation: Problems in request:\nmissing packages: themissing"
+		}
+    ]}`
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("blueprints", "depsolve", "cli-test-bp-1")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, depsolveCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.NotContains(t, string(stdout), "{")
+	assert.Contains(t, string(stdout), "blueprint: cli-test-bp-1 v0.0.1")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stderr), "BlueprintsError: cli-test-bp-1: DNF error occured:")
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/depsolve/cli-test-bp-1", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsBadDepsolveJSON(t *testing.T) {
+	// Test the "blueprints depsolve" command with missing package
+	json := `{
+    "blueprints": [
+        {
+            "blueprint": {
+                "description": "composer-cli blueprint test 1",
+                "name": "cli-test-bp-1",
+                "packages": [
+                    {
+                        "name": "bash",
+                        "version": "*"
+                    },
+                    {
+                        "name": "themissing",
+                        "version": "*"
+                    }
+                ],
+                "version": "0.0.1"
+            }
+		}],
+    "errors": [
+        {
+            "id": "BlueprintsError",
+            "msg": "cli-test-bp-1: DNF error occured: MarkingErrors: Error occurred when marking packages for installation: Problems in request:\nmissing packages: themissing"
+		}
+    ]}`
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "depsolve", "cli-test-bp-1")
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, depsolveCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
+	assert.Contains(t, string(stdout), "\"id\": \"BlueprintsError\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"cli-test-bp-1: DNF error occured:")
+	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/depsolve/cli-test-bp-1\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, "", string(stderr))
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/depsolve/cli-test-bp-1", mc.Req.URL.Path)
 }

--- a/cmd/composer-cli/blueprints/freeze.go
+++ b/cmd/composer-cli/blueprints/freeze.go
@@ -67,14 +67,8 @@ func freeze(cmd *cobra.Command, args []string) (rcErr error) {
 	if err != nil {
 		return root.ExecutionError(cmd, "Save Error: %s", err)
 	}
-	if root.JSONOutput {
-		return nil
-	}
 	if len(errors) > 0 {
-		for _, e := range errors {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", e.String())
-		}
-		rcErr = root.ExecutionError(cmd, "")
+		rcErr = root.ExecutionErrors(cmd, errors)
 	}
 
 	for _, bp := range bps {
@@ -113,9 +107,12 @@ func freeze(cmd *cobra.Command, args []string) (rcErr error) {
 func freezeShow(cmd *cobra.Command, args []string) error {
 	names := root.GetCommaArgs(args)
 	if root.JSONOutput {
-		_, _, err := root.Client.GetFrozenBlueprintsJSON(names)
+		_, errors, err := root.Client.GetFrozenBlueprintsJSON(names)
 		if err != nil {
 			return root.ExecutionError(cmd, "Save Error: %s", err)
+		}
+		if errors != nil {
+			return root.ExecutionErrors(cmd, errors)
 		}
 		return nil
 	}
@@ -137,14 +134,8 @@ func freezeSave(cmd *cobra.Command, args []string) (rcErr error) {
 	if err != nil {
 		return root.ExecutionError(cmd, "Save Error: %s", err)
 	}
-	if root.JSONOutput {
-		return nil
-	}
 	if len(errors) > 0 {
-		for _, e := range errors {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", e.String())
-		}
-		rcErr = root.ExecutionError(cmd, "")
+		rcErr = root.ExecutionErrors(cmd, errors)
 	}
 
 	for _, bp := range bps {

--- a/cmd/composer-cli/blueprints/freeze_test.go
+++ b/cmd/composer-cli/blueprints/freeze_test.go
@@ -1,0 +1,346 @@
+// Copyright 2021 by Red Hat, Inc. All rights reserved.
+// Use of this source is goverend by the Apache License
+// that can be found in the LICENSE file.
+
+package blueprints
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/osbuild/weldr-client/v2/cmd/composer-cli/root"
+)
+
+func TestCmdBlueprintsFreeze(t *testing.T) {
+	// Test the "blueprints freeze" command
+	json := `{
+        "blueprints": [
+		    {
+                "blueprint": {
+                    "description": "Install tmux",
+                    "distro": "",
+                    "groups": [],
+                    "modules": [],
+                    "name": "cli-test-bp-1",
+                    "packages": [
+                        {
+                            "name": "tmux",
+                            "version": "3.1c-2.fc34.x86_64"
+                        }
+                    ],
+                    "version": "0.0.3"
+                }
+            }
+        ],
+        "errors": [
+            {
+                "id": "UnknownBlueprint",
+                "msg": "test-no-bp: blueprint not found"
+            }
+        ]
+}`
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("blueprints", "freeze", "cli-test-bp-1,test-no-bp")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, freezeCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.NotContains(t, string(stdout), "{")
+	assert.Contains(t, string(stdout), "blueprint: cli-test-bp-1 v0.0.3")
+	assert.Contains(t, string(stdout), "tmux-3.1c-2.fc34.x86_64")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stderr), "UnknownBlueprint: test-no-bp: blueprint not found")
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/freeze/cli-test-bp-1,test-no-bp", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsFreezeJSON(t *testing.T) {
+	// Test the "blueprints freeze" command
+	json := `{
+        "blueprints": [
+		    {
+                "blueprint": {
+                    "description": "Install tmux",
+                    "distro": "",
+                    "groups": [],
+                    "modules": [],
+                    "name": "cli-test-bp-1",
+                    "packages": [
+                        {
+                            "name": "tmux",
+                            "version": "3.1c-2.fc34.x86_64"
+                        }
+                    ],
+                    "version": "0.0.3"
+                }
+            }
+        ],
+        "errors": [
+            {
+                "id": "UnknownBlueprint",
+                "msg": "test-no-bp: blueprint not found"
+            }
+        ]
+}`
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "freeze", "cli-test-bp-1,test-no-bp")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, freezeCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
+	assert.Contains(t, string(stdout), "\"version\": \"3.1c-2.fc34.x86_64\"")
+	assert.Contains(t, string(stdout), "\"id\": \"UnknownBlueprint\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"test-no-bp: blueprint not found\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, "", string(stderr))
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/freeze/cli-test-bp-1,test-no-bp", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsFreezeSave(t *testing.T) {
+	// Test the "blueprints freeze save" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "blueprints": [
+        {
+			"blueprint": {
+				"description": "Install tmux",
+				"distro": "",
+				"groups": [],
+				"modules": [],
+				"name": "cli-test-bp-1",
+				"packages": [
+					{
+						"name": "tmux",
+						"version": "3.1c-2.fc34.x86_64"
+					}
+				],
+				"version": "0.0.3"
+			}
+	   }],
+    "errors": []
+}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	dir, err := ioutil.TempDir("", "test-bp-save-*")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	prevDir, _ := os.Getwd()
+	err = os.Chdir(dir)
+	require.Nil(t, err)
+	//nolint:errcheck
+	defer os.Chdir(prevDir)
+
+	cmd, out, err := root.ExecuteTest("blueprints", "freeze", "save", "cli-test-bp-1")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, freezeSaveCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/freeze/cli-test-bp-1", mc.Req.URL.Path)
+
+	_, err = os.Stat("cli-test-bp-1.frozen.toml")
+	assert.Nil(t, err)
+}
+
+func TestCmdBlueprintsFreezeSaveJSON(t *testing.T) {
+	// Test the "blueprints freeze save" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "blueprints": [
+        {
+			"blueprint": {
+				"description": "Install tmux",
+				"distro": "",
+				"groups": [],
+				"modules": [],
+				"name": "cli-test-bp-1",
+				"packages": [
+					{
+						"name": "tmux",
+						"version": "3.1c-2.fc34.x86_64"
+					}
+				],
+				"version": "0.0.3"
+			}
+	   }],
+    "errors": []
+}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	dir, err := ioutil.TempDir("", "test-bp-save-*")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	prevDir, _ := os.Getwd()
+	err = os.Chdir(dir)
+	require.Nil(t, err)
+	//nolint:errcheck
+	defer os.Chdir(prevDir)
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "freeze", "save", "cli-test-bp-1")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, freezeSaveCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
+	assert.Contains(t, string(stdout), "\"version\": \"3.1c-2.fc34.x86_64\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/freeze/cli-test-bp-1", mc.Req.URL.Path)
+
+	_, err = os.Stat("cli-test-bp-1.frozen.toml")
+	assert.Nil(t, err)
+}
+
+func TestCmdBlueprintsFreezeShow(t *testing.T) {
+	// Test the "blueprints freeze show" command
+	toml := `name = "cli-test-bp-1"
+description = "Install tmux"
+version = "0.0.3"
+modules = []
+groups = []
+distro = ""
+
+[[packages]]
+name = "tmux"
+version = "3.1c-2.fc34.x86_64"
+}`
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(toml))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("blueprints", "freeze", "show", "cli-test-bp-1")
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, freezeShowCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.NotContains(t, string(stdout), "{")
+	assert.Contains(t, string(stdout), "name = \"cli-test-bp-1\"")
+	assert.Contains(t, string(stdout), "[[packages]]")
+	assert.Contains(t, string(stdout), "version = \"3.1c-2.fc34.x86_64\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, "", string(stderr))
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/freeze/cli-test-bp-1", mc.Req.URL.Path)
+	assert.Equal(t, "format=toml", mc.Req.URL.RawQuery)
+}
+
+func TestCmdBlueprintsFreezeShowJSON(t *testing.T) {
+	// Test the "blueprints freeze show" command
+	json := `{
+        "blueprints": [
+		    {
+                "blueprint": {
+                    "description": "Install tmux",
+                    "distro": "",
+                    "groups": [],
+                    "modules": [],
+                    "name": "cli-test-bp-1",
+                    "packages": [
+                        {
+                            "name": "tmux",
+                            "version": "3.1c-2.fc34.x86_64"
+                        }
+                    ],
+                    "version": "0.0.3"
+                }
+            }
+        ],
+        "errors": [
+        ]
+}`
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "freeze", "show", "cli-test-bp-1")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, freezeShowCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
+	assert.Contains(t, string(stdout), "\"version\": \"3.1c-2.fc34.x86_64\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/freeze/cli-test-bp-1\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, "", string(stderr))
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/freeze/cli-test-bp-1", mc.Req.URL.Path)
+}

--- a/cmd/composer-cli/blueprints/list.go
+++ b/cmd/composer-cli/blueprints/list.go
@@ -28,14 +28,11 @@ func init() {
 
 func list(cmd *cobra.Command, args []string) error {
 	blueprints, resp, err := root.Client.ListBlueprints()
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "List Error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "List Error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	sort.Strings(blueprints)

--- a/cmd/composer-cli/blueprints/list_test.go
+++ b/cmd/composer-cli/blueprints/list_test.go
@@ -37,6 +37,7 @@ func TestCmdBlueprintsList(t *testing.T) {
 	})
 
 	cmd, out, err := root.ExecuteTest("blueprints", "list")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -45,8 +46,49 @@ func TestCmdBlueprintsList(t *testing.T) {
 	assert.Equal(t, cmd, listCmd)
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
+	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "http-server-prod")
 	assert.Contains(t, string(stdout), "nfs-server-test")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/list", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsListJSON(t *testing.T) {
+	// Test the "blueprints list" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		var json string
+		if limit == 0 {
+			json = `{"blueprints": [], "total": 2, "offset": 0, "limit": 0}`
+		} else {
+			json = `{"blueprints": ["http-server-prod", "nfs-server-test"], "total": 2, "offset": 0, "limit": 2}`
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "list")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"blueprints\": [\n")
+	assert.Contains(t, string(stdout), "\"http-server-prod\",")
+	assert.Contains(t, string(stdout), "\"total\": 2")
+	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/list?limit=2\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)

--- a/cmd/composer-cli/blueprints/push.go
+++ b/cmd/composer-cli/blueprints/push.go
@@ -42,14 +42,8 @@ func push(cmd *cobra.Command, args []string) (rcErr error) {
 			rcErr = root.ExecutionError(cmd, "")
 			continue
 		}
-		if root.JSONOutput {
-			continue
-		}
 		if resp != nil && !resp.Status {
-			for _, e := range resp.AllErrors() {
-				fmt.Fprintf(os.Stderr, "ERROR: %s\n", e)
-			}
-			rcErr = root.ExecutionError(cmd, "")
+			rcErr = root.ExecutionErrors(cmd, resp.Errors)
 		}
 	}
 

--- a/cmd/composer-cli/blueprints/push_test.go
+++ b/cmd/composer-cli/blueprints/push_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestCmdBlueprintsPush(t *testing.T) {
-	// Test the "blueprints list" command
+	// Test the "blueprints push" command
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		json := `{"status": true}`
 		return &http.Response{
@@ -41,6 +41,7 @@ version = "*"`))
 	require.Nil(t, err)
 
 	cmd, out, err := root.ExecuteTest("blueprints", "push", tmpBp.Name())
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -57,8 +58,51 @@ version = "*"`))
 	assert.Equal(t, "/api/v1/blueprints/new", mc.Req.URL.Path)
 }
 
+func TestCmdBlueprintsPushJSON(t *testing.T) {
+	// Test the "blueprints push" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{"status": true}`
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Need a temporary test file
+	tmpBp, err := ioutil.TempFile("", "test-bp-*.toml")
+	require.Nil(t, err)
+	defer os.Remove(tmpBp.Name())
+
+	_, err = tmpBp.Write([]byte(`name = "test-bp-random"
+description = "A test toml file"
+version = "0.0.1"
+[[packages]]
+name = "bash"
+version = "*"`))
+	require.Nil(t, err)
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "push", tmpBp.Name())
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, pushCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": true")
+	assert.Contains(t, string(stdout), "\"method\": \"POST\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/new\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "POST", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/new", mc.Req.URL.Path)
+}
+
 func TestCmdBlueprintsPushError(t *testing.T) {
-	// Test the "blueprints list" command
+	// Test the "blueprints push" command
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		json := `{
     "errors": [
@@ -91,9 +135,9 @@ version = "*"`))
 	require.Nil(t, err)
 
 	cmd, out, err := root.ExecuteTest("blueprints", "push", tmpBp.Name())
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
-
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
@@ -104,6 +148,59 @@ version = "*"`))
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "BlueprintsError")
+	assert.Equal(t, "POST", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/new", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsPushErrorJSON(t *testing.T) {
+	// Test the "blueprints push" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "errors": [
+        {
+            "id": "BlueprintsError",
+            "msg": "400 Bad Request: The browser (or proxy) sent a request that this server could not understand: Near line 1 (last key parsed 'name'): strings cannot contain newlines"
+        }
+    ],
+    "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Need a temporary test file
+	tmpBp, err := ioutil.TempFile("", "test-bp-*.toml")
+	require.Nil(t, err)
+	defer os.Remove(tmpBp.Name())
+
+	_, err = tmpBp.Write([]byte(`name = "test-bp-random"
+description = "A broken toml file
+version = "0.0.1"
+[[packages]]
+name = "bash"
+version = "*"`))
+	require.Nil(t, err)
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "push", tmpBp.Name())
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, pushCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"id\": \"BlueprintsError\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"400 Bad Request:")
+	assert.Contains(t, string(stdout), "\"status\": 400")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
 	assert.Equal(t, "/api/v1/blueprints/new", mc.Req.URL.Path)
 }

--- a/cmd/composer-cli/blueprints/save.go
+++ b/cmd/composer-cli/blueprints/save.go
@@ -36,14 +36,8 @@ func saveToml(cmd *cobra.Command, args []string) (rcErr error) {
 	if err != nil {
 		return root.ExecutionError(cmd, "Save Error: %s", err)
 	}
-	if root.JSONOutput {
-		return nil
-	}
 	if len(errors) > 0 {
-		for _, e := range errors {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", e.String())
-		}
-		rcErr = root.ExecutionError(cmd, "")
+		rcErr = root.ExecutionErrors(cmd, errors)
 	}
 
 	for _, bp := range bps {

--- a/cmd/composer-cli/blueprints/save_test.go
+++ b/cmd/composer-cli/blueprints/save_test.go
@@ -62,6 +62,7 @@ func TestCmdBlueprintsSave(t *testing.T) {
 	defer os.Chdir(prevDir)
 
 	cmd, out, err := root.ExecuteTest("blueprints", "save", "simple")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -79,4 +80,180 @@ func TestCmdBlueprintsSave(t *testing.T) {
 
 	_, err = os.Stat("simple.toml")
 	assert.Nil(t, err)
+}
+
+func TestCmdBlueprintsSaveUnknown(t *testing.T) {
+	// Test the "blueprints save " command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "blueprints": [
+    ],
+    "changes": [
+    ],
+    "errors": [
+		{
+            "id": "UnknownBlueprint",
+            "msg": "test-no-bp: "
+        }
+	]
+}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	dir, err := ioutil.TempDir("", "test-bp-save-*")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	prevDir, _ := os.Getwd()
+	err = os.Chdir(dir)
+	require.Nil(t, err)
+	//nolint:errcheck
+	defer os.Chdir(prevDir)
+
+	cmd, out, err := root.ExecuteTest("blueprints", "save", "test-no-bp")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, saveCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stderr), "UnknownBlueprint: test-no-bp")
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/info/test-no-bp", mc.Req.URL.Path)
+
+	_, err = os.Stat("test-no-bp.toml")
+	assert.NotNil(t, err)
+}
+
+func TestCmdBlueprintsSaveJSON(t *testing.T) {
+	// Test the "blueprints save " command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "blueprints": [
+        {
+            "description": "simple blueprint",
+            "groups": [],
+            "modules": [],
+            "name": "simple",
+            "packages": [
+                {
+                    "name": "bash",
+                    "version": "*"
+                }
+            ],
+            "version": "0.1.0"
+        }
+    ],
+    "changes": [
+        {
+            "changed": false,
+            "name": "simple"
+        }
+    ],
+    "errors": []
+}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	dir, err := ioutil.TempDir("", "test-bp-save-*")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	prevDir, _ := os.Getwd()
+	err = os.Chdir(dir)
+	require.Nil(t, err)
+	//nolint:errcheck
+	defer os.Chdir(prevDir)
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "save", "simple")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, saveCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"name\": \"simple\"")
+	assert.Contains(t, string(stdout), "\"changed\": false")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/info/simple", mc.Req.URL.Path)
+
+	_, err = os.Stat("simple.toml")
+	assert.Nil(t, err)
+}
+
+func TestCmdBlueprintsSaveUnknownJSON(t *testing.T) {
+	// Test the "blueprints save " command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "blueprints": [
+    ],
+    "changes": [
+    ],
+    "errors": [
+		{
+            "id": "UnknownBlueprint",
+            "msg": "test-no-bp: "
+        }
+	]
+}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	dir, err := ioutil.TempDir("", "test-bp-save-*")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	prevDir, _ := os.Getwd()
+	err = os.Chdir(dir)
+	require.Nil(t, err)
+	//nolint:errcheck
+	defer os.Chdir(prevDir)
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "save", "test-no-bp")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, saveCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"id\": \"UnknownBlueprint\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"test-no-bp: \"")
+	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/info/test-no-bp\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/info/test-no-bp", mc.Req.URL.Path)
+
+	_, err = os.Stat("test-no-bp.toml")
+	assert.NotNil(t, err)
 }

--- a/cmd/composer-cli/blueprints/show.go
+++ b/cmd/composer-cli/blueprints/show.go
@@ -6,7 +6,6 @@ package blueprints
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -31,9 +30,12 @@ func show(cmd *cobra.Command, args []string) (rcErr error) {
 	names := root.GetCommaArgs(args)
 
 	if root.JSONOutput {
-		_, _, err := root.Client.GetBlueprintsJSON(names)
+		_, errors, err := root.Client.GetBlueprintsJSON(names)
 		if err != nil {
 			return root.ExecutionError(cmd, "Show Error: %s", err)
+		}
+		if errors != nil {
+			return root.ExecutionErrors(cmd, errors)
 		}
 		return nil
 	}
@@ -43,8 +45,7 @@ func show(cmd *cobra.Command, args []string) (rcErr error) {
 		return root.ExecutionError(cmd, "Show Error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		fmt.Fprintf(os.Stderr, "ERROR: Show: %s\n", resp.String())
-		rcErr = root.ExecutionError(cmd, "")
+		rcErr = root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	for _, bp := range blueprints {

--- a/cmd/composer-cli/blueprints/tag.go
+++ b/cmd/composer-cli/blueprints/tag.go
@@ -29,11 +29,8 @@ func tag(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return root.ExecutionError(cmd, "Tag Error: %s", err)
 	}
-	if root.JSONOutput {
-		return nil
-	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "Tag Error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	return nil

--- a/cmd/composer-cli/blueprints/undo.go
+++ b/cmd/composer-cli/blueprints/undo.go
@@ -29,11 +29,8 @@ func undo(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return root.ExecutionError(cmd, "Undo Error: %s", err)
 	}
-	if root.JSONOutput {
-		return nil
-	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "Undo Error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	return nil

--- a/cmd/composer-cli/blueprints/workspace.go
+++ b/cmd/composer-cli/blueprints/workspace.go
@@ -43,14 +43,8 @@ func workspace(cmd *cobra.Command, args []string) (rcErr error) {
 			rcErr = root.ExecutionError(cmd, "")
 			continue
 		}
-		if root.JSONOutput {
-			continue
-		}
 		if resp != nil && !resp.Status {
-			for _, e := range resp.AllErrors() {
-				fmt.Fprintf(os.Stderr, "ERROR: %s\n", e)
-			}
-			rcErr = root.ExecutionError(cmd, "")
+			rcErr = root.ExecutionErrors(cmd, resp.Errors)
 		}
 	}
 

--- a/cmd/composer-cli/blueprints/workspace_test.go
+++ b/cmd/composer-cli/blueprints/workspace_test.go
@@ -41,6 +41,7 @@ version = "*"`))
 	require.Nil(t, err)
 
 	cmd, out, err := root.ExecuteTest("blueprints", "workspace", tmpBp.Name())
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -50,6 +51,49 @@ version = "*"`))
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "POST", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/workspace", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsWorkspaceJSON(t *testing.T) {
+	// Test the "blueprints workspace" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{"status": true}`
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Need a temporary test file
+	tmpBp, err := ioutil.TempFile("", "test-bp-*.toml")
+	require.Nil(t, err)
+	defer os.Remove(tmpBp.Name())
+
+	_, err = tmpBp.Write([]byte(`name = "test-bp-random"
+description = "A test toml file"
+version = "0.0.1"
+[[packages]]
+name = "bash"
+version = "*"`))
+	require.Nil(t, err)
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "workspace", tmpBp.Name())
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, workspaceCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": true")
+	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/workspace\"")
+	assert.Contains(t, string(stdout), "\"method\": \"POST\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -91,9 +135,9 @@ version = "*"`))
 	require.Nil(t, err)
 
 	cmd, out, err := root.ExecuteTest("blueprints", "workspace", tmpBp.Name())
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
-
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
@@ -104,6 +148,61 @@ version = "*"`))
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "BlueprintsError")
+	assert.Equal(t, "POST", mc.Req.Method)
+	assert.Equal(t, "/api/v1/blueprints/workspace", mc.Req.URL.Path)
+}
+
+func TestCmdBlueprintsWorkspaceErrorJSON(t *testing.T) {
+	// Test the "blueprints list" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "errors": [
+        {
+            "id": "BlueprintsError",
+            "msg": "400 Bad Request: The browser (or proxy) sent a request that this server could not understand: Near line 1 (last key parsed 'name'): strings cannot contain newlines"
+        }
+    ],
+    "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Need a temporary test file
+	tmpBp, err := ioutil.TempFile("", "test-bp-*.toml")
+	require.Nil(t, err)
+	defer os.Remove(tmpBp.Name())
+
+	_, err = tmpBp.Write([]byte(`name = "test-bp-random"
+description = "A broken toml file
+version = "0.0.1"
+[[packages]]
+name = "bash"
+version = "*"`))
+	require.Nil(t, err)
+
+	cmd, out, err := root.ExecuteTest("--json", "blueprints", "workspace", tmpBp.Name())
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, workspaceCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"id\": \"BlueprintsError\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"400 Bad Request: ")
+	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/blueprints/workspace\"")
+	assert.Contains(t, string(stdout), "\"method\": \"POST\"")
+	assert.Contains(t, string(stdout), "\"status\": 400")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
 	assert.Equal(t, "/api/v1/blueprints/workspace", mc.Req.URL.Path)
 }

--- a/cmd/composer-cli/compose/cancel.go
+++ b/cmd/composer-cli/compose/cancel.go
@@ -5,9 +5,6 @@
 package compose
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/osbuild/weldr-client/v2/cmd/composer-cli/root"
@@ -29,17 +26,11 @@ func init() {
 
 func cancelComposes(cmd *cobra.Command, args []string) error {
 	_, errors, err := root.Client.CancelCompose(args[0])
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "Cancel Error: %s", err)
 	}
 	if len(errors) > 0 {
-		for _, e := range errors {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", e.String())
-		}
-		return root.ExecutionError(cmd, "")
+		return root.ExecutionErrors(cmd, errors)
 	}
 
 	return nil

--- a/cmd/composer-cli/compose/cancel_test.go
+++ b/cmd/composer-cli/compose/cancel_test.go
@@ -37,6 +37,7 @@ func TestCmdComposeCancel(t *testing.T) {
 
 	// Cancel a compose
 	cmd, out, err := root.ExecuteTest("compose", "cancel", "ac188b76-138a-452c-82fb-5cc651986991")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, cmd)
@@ -46,6 +47,51 @@ func TestCmdComposeCancel(t *testing.T) {
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "DELETE", mc.Req.Method)
+	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	mc.Req.Body.Close()
+	require.Nil(t, err)
+	assert.Equal(t, []byte(""), sentBody)
+	assert.Equal(t, "/api/v1/compose/cancel/ac188b76-138a-452c-82fb-5cc651986991", mc.Req.URL.Path)
+}
+
+func TestCmdComposeCancelJSON(t *testing.T) {
+	// Test the "compose cancel" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+		"uuids": [
+        {
+            "uuid": "ac188b76-138a-452c-82fb-5cc651986991",
+            "status": true
+        }
+    ],
+    "errors": []
+}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Cancel a compose
+	cmd, out, err := root.ExecuteTest("--json", "compose", "cancel", "ac188b76-138a-452c-82fb-5cc651986991")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, cancelCmd)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": true")
+	assert.Contains(t, string(stdout), "\"uuid\": \"ac188b76-138a-452c-82fb-5cc651986991\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/compose/cancel/ac188b76-138a-452c-82fb-5cc651986991\"")
+	assert.Contains(t, string(stdout), "\"method\": \"DELETE")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -79,8 +125,10 @@ func TestCmdComposeCancelUnknown(t *testing.T) {
 
 	// Cancel Unknown compose
 	cmd, out, err := root.ExecuteTest("compose", "cancel", "4b668b1a-e6b8-4dce-8828-4a8e3bef2345")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, cancelCmd)
 	require.NotNil(t, out.Stdout)
@@ -91,6 +139,53 @@ func TestCmdComposeCancelUnknown(t *testing.T) {
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("ERROR: UnknownUUID: Compose 4b668b1a-e6b8-4dce-8828-4a8e3bef2345 doesn't exist\n"), stderr)
+	assert.Equal(t, "DELETE", mc.Req.Method)
+	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	mc.Req.Body.Close()
+	require.Nil(t, err)
+	assert.Equal(t, []byte(""), sentBody)
+	assert.Equal(t, "/api/v1/compose/cancel/4b668b1a-e6b8-4dce-8828-4a8e3bef2345", mc.Req.URL.Path)
+}
+
+func TestCmdComposeCancelUnknownJSON(t *testing.T) {
+	// Test the "compose cancel" command with one unknown uuid
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "status": false,
+    "errors": [
+        {
+            "id": "UnknownUUID",
+            "msg": "Compose 4b668b1a-e6b8-4dce-8828-4a8e3bef2345 doesn't exist"
+        }
+    ]
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Cancel Unknown compose
+	cmd, out, err := root.ExecuteTest("--json", "compose", "cancel", "4b668b1a-e6b8-4dce-8828-4a8e3bef2345")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, cancelCmd)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/compose/cancel/4b668b1a-e6b8-4dce-8828-4a8e3bef2345\"")
+	assert.Contains(t, string(stdout), "\"method\": \"DELETE")
+	assert.Contains(t, string(stdout), "\"status\": 400")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
 	sentBody, err := ioutil.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()

--- a/cmd/composer-cli/compose/delete.go
+++ b/cmd/composer-cli/compose/delete.go
@@ -5,9 +5,6 @@
 package compose
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/osbuild/weldr-client/v2/cmd/composer-cli/root"
@@ -29,17 +26,11 @@ func init() {
 
 func deleteComposes(cmd *cobra.Command, args []string) error {
 	_, errors, err := root.Client.DeleteComposes(args)
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "List Error: %s", err)
 	}
 	if len(errors) > 0 {
-		for _, e := range errors {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", e.String())
-		}
-		return root.ExecutionError(cmd, "")
+		return root.ExecutionErrors(cmd, errors)
 	}
 
 	return nil

--- a/cmd/composer-cli/compose/delete_test.go
+++ b/cmd/composer-cli/compose/delete_test.go
@@ -37,6 +37,7 @@ func TestCmdComposeDelete(t *testing.T) {
 
 	// Delete a compose
 	cmd, out, err := root.ExecuteTest("compose", "delete", "ac188b76-138a-452c-82fb-5cc651986991")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, cmd)
@@ -46,6 +47,50 @@ func TestCmdComposeDelete(t *testing.T) {
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "DELETE", mc.Req.Method)
+	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	mc.Req.Body.Close()
+	require.Nil(t, err)
+	assert.Equal(t, []byte(""), sentBody)
+	assert.Equal(t, "/api/v1/compose/delete/ac188b76-138a-452c-82fb-5cc651986991", mc.Req.URL.Path)
+}
+
+func TestCmdComposeDeleteJSON(t *testing.T) {
+	// Test the "compose delete" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+		"uuids": [
+        {
+            "uuid": "ac188b76-138a-452c-82fb-5cc651986991",
+            "status": true
+        }
+    ],
+    "errors": []
+}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Delete a compose
+	cmd, out, err := root.ExecuteTest("--json", "compose", "delete", "ac188b76-138a-452c-82fb-5cc651986991")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, deleteCmd)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": true")
+	assert.Contains(t, string(stdout), "\"uuid\": \"ac188b76-138a-452c-82fb-5cc651986991\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/compose/delete/ac188b76-138a-452c-82fb-5cc651986991\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -83,6 +128,7 @@ func TestCmdComposeDeleteUnknown(t *testing.T) {
 
 	// Delete a compose
 	cmd, out, err := root.ExecuteTest("compose", "delete", "ac188b76-138a-452c-82fb-5cc651986991", "4b668b1a-e6b8-4dce-8828-4a8e3bef2345")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
 	require.NotNil(t, cmd)
@@ -95,6 +141,57 @@ func TestCmdComposeDeleteUnknown(t *testing.T) {
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("ERROR: UnknownUUID: compose 4b668b1a-e6b8-4dce-8828-4a8e3bef2345 doesn't exist\n"), stderr)
+	assert.Equal(t, "DELETE", mc.Req.Method)
+	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	mc.Req.Body.Close()
+	require.Nil(t, err)
+	assert.Equal(t, []byte(""), sentBody)
+	assert.Equal(t, "/api/v1/compose/delete/ac188b76-138a-452c-82fb-5cc651986991,4b668b1a-e6b8-4dce-8828-4a8e3bef2345", mc.Req.URL.Path)
+}
+
+func TestCmdComposeDeleteUnknownJSON(t *testing.T) {
+	// Test the "compose delete" command with one unknown uuid
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+		"uuids": [
+        {
+            "uuid": "ac188b76-138a-452c-82fb-5cc651986991",
+            "status": true
+        }
+    ],
+    "errors": [
+        {
+            "id": "UnknownUUID",
+            "msg": "compose 4b668b1a-e6b8-4dce-8828-4a8e3bef2345 doesn't exist"
+        }
+	]
+}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Delete a compose
+	cmd, out, err := root.ExecuteTest("--json", "compose", "delete", "ac188b76-138a-452c-82fb-5cc651986991", "4b668b1a-e6b8-4dce-8828-4a8e3bef2345")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, deleteCmd)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": true")
+	assert.Contains(t, string(stdout), "\"uuid\": \"ac188b76-138a-452c-82fb-5cc651986991\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/compose/delete/ac188b76-138a-452c-82fb-5cc651986991,4b668b1a-e6b8-4dce-8828-4a8e3bef2345\"")
+	assert.Contains(t, string(stdout), "\"id\": \"UnknownUUID\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"compose 4b668b1a-e6b8-4dce-8828-4a8e3bef2345 doesn't exist\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
 	sentBody, err := ioutil.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()

--- a/cmd/composer-cli/compose/image.go
+++ b/cmd/composer-cli/compose/image.go
@@ -32,7 +32,7 @@ func getImage(cmd *cobra.Command, args []string) (rcErr error) {
 		return root.ExecutionError(cmd, "Image error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "Image error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	fmt.Println(fn)

--- a/cmd/composer-cli/compose/info.go
+++ b/cmd/composer-cli/compose/info.go
@@ -6,7 +6,6 @@ package compose
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -27,19 +26,13 @@ func init() {
 	composeCmd.AddCommand(infoCmd)
 }
 
-func info(cmd *cobra.Command, args []string) (rcErr error) {
+func info(cmd *cobra.Command, args []string) error {
 	info, resp, err := root.Client.ComposeInfo(args[0])
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "Info Error: %s", err)
 	}
 	if resp != nil {
-		for _, e := range resp.Errors {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", e.String())
-		}
-		return root.ExecutionError(cmd, "")
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	var imageSize string
@@ -69,5 +62,5 @@ func info(cmd *cobra.Command, args []string) (rcErr error) {
 		fmt.Printf("    %s\n", d)
 	}
 
-	return rcErr
+	return nil
 }

--- a/cmd/composer-cli/compose/info_test.go
+++ b/cmd/composer-cli/compose/info_test.go
@@ -75,6 +75,7 @@ func TestCmdComposeInfo(t *testing.T) {
 
 	// Get info about a compose
 	cmd, out, err := root.ExecuteTest("compose", "info", "ddcf50e5-1ffa-4de6-95ed-42749ac1f389")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -87,6 +88,83 @@ func TestCmdComposeInfo(t *testing.T) {
 	assert.Contains(t, string(stdout), "FINISHED")
 	assert.Contains(t, string(stdout), "bash-*")
 	assert.Contains(t, string(stdout), "chrony-4.0-1.fc33.x86_64")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdComposeInfoJSON(t *testing.T) {
+	// Test the "compose info" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "blueprint": {
+        "customizations": {
+            "user": [
+                {
+                    "name": "root",
+                    "password": "qweqweqwe"
+                }
+            ]
+        },
+        "description": "composer-cli blueprint test 1",
+        "groups": [],
+        "modules": [
+            {
+                "name": "util-linux",
+                "version": "*"
+            }
+        ],
+        "name": "cli-test-bp-1",
+        "packages": [
+            {
+                "name": "bash",
+                "version": "*"
+            }
+        ],
+        "version": "0.0.1"
+    },
+    "commit": "",
+    "compose_type": "qcow2",
+    "config": "",
+    "deps": {
+        "packages": [
+			{
+                "arch": "x86_64",
+                "check_gpg": true,
+                "checksum": "sha256:e711b7570827fb4fdc50a706549a377491203963fea7260db7f879f71bbf056d",
+                "epoch": 0,
+                "name": "chrony",
+                "release": "1.fc33",
+                "remote_location": "http://mirror.siena.edu/fedora/linux/updates/33/Everything/x86_64/Packages/c/chrony-4.0-1.fc33.x86_64.rpm",
+                "version": "4.0"
+            }
+		]
+    },
+    "id": "ddcf50e5-1ffa-4de6-95ed-42749ac1f389",
+    "image_size": 2147483648,
+    "queue_status": "FINISHED"
+}`
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get info about a compose
+	cmd, out, err := root.ExecuteTest("--json", "compose", "info", "ddcf50e5-1ffa-4de6-95ed-42749ac1f389")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, infoCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"id\": \"ddcf50e5-1ffa-4de6-95ed-42749ac1f389\"")
+	assert.Contains(t, string(stdout), "\"queue_status\": \"FINISHED\"")
+	assert.Contains(t, string(stdout), "\"name\": \"chrony\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -114,8 +192,10 @@ func TestCmdComposeInfoUnknown(t *testing.T) {
 
 	// Get info about a compose
 	cmd, out, err := root.ExecuteTest("compose", "info", "328e96c9-41d7-423f-92ec-94e390c093ac")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
@@ -126,5 +206,46 @@ func TestCmdComposeInfoUnknown(t *testing.T) {
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "UnknownUUID: 328e96c9-41d7-423f-92ec-94e390c093ac is not")
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdComposeInfoUnknownJSON(t *testing.T) {
+	// Test the "compose info" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "errors": [
+        {
+            "id": "UnknownUUID",
+            "msg": "328e96c9-41d7-423f-92ec-94e390c093ac is not a valid build uuid"
+        }
+    ],
+    "status": false
+}`
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get info about a compose
+	cmd, out, err := root.ExecuteTest("--json", "compose", "info", "328e96c9-41d7-423f-92ec-94e390c093ac")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, infoCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"id\": \"UnknownUUID\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"328e96c9-41d7-423f-92ec-94e390c093ac is not a valid build uuid\"")
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/compose/info/328e96c9-41d7-423f-92ec-94e390c093ac\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
 }

--- a/cmd/composer-cli/compose/list.go
+++ b/cmd/composer-cli/compose/list.go
@@ -6,7 +6,6 @@ package compose
 
 import (
 	"fmt"
-	"os"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -32,17 +31,11 @@ func init() {
 
 func list(cmd *cobra.Command, args []string) (rcErr error) {
 	composes, errors, err := root.Client.ListComposes()
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "List Error: %s", err)
 	}
 	if len(errors) > 0 {
-		for _, e := range errors {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", e.String())
-		}
-		rcErr = root.ExecutionError(cmd, "")
+		rcErr = root.ExecutionErrors(cmd, errors)
 	}
 
 	var filter []string

--- a/cmd/composer-cli/compose/list_test.go
+++ b/cmd/composer-cli/compose/list_test.go
@@ -88,6 +88,7 @@ func TestCmdComposeList(t *testing.T) {
 
 	// List all of the composes
 	cmd, out, err := root.ExecuteTest("compose", "list")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -107,6 +108,7 @@ func TestCmdComposeList(t *testing.T) {
 
 	// List all of the running composes
 	cmd, out, err = root.ExecuteTest("compose", "list", "running")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -126,6 +128,7 @@ func TestCmdComposeList(t *testing.T) {
 
 	// List all of the finised composes
 	cmd, out, err = root.ExecuteTest("compose", "list", "finished")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -145,6 +148,7 @@ func TestCmdComposeList(t *testing.T) {
 
 	// List all of the failed composes
 	cmd, out, err = root.ExecuteTest("compose", "list", "failed")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -164,6 +168,7 @@ func TestCmdComposeList(t *testing.T) {
 
 	// List all of the finished and failed composes
 	cmd, out, err = root.ExecuteTest("compose", "list", "finished", "failed")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -177,6 +182,97 @@ func TestCmdComposeList(t *testing.T) {
 	assert.Contains(t, string(stdout), "cefd01c3-629f-493e-af72-3f12981bb77b")
 	assert.Contains(t, string(stdout), "d5903571-55e2-4a18-8643-2d90611fcb11")
 	stderr, err = ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdComposeListJSON(t *testing.T) {
+	// Test the "compose list" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		var json string
+		if request.URL.Path == "/api/v1/compose/queue" {
+			json = `{
+	"new": [
+		{
+			"id": "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7",
+			"blueprint": "tmux-bcl",
+			"version": "1.1.0",
+			"compose_type": "qcow2",
+			"image_size": 0,
+			"queue_status": "WAITING",
+			"job_created": 1608165958.8658934
+		}
+    ],
+    "run": [
+        {
+            "id": "6d185e04-b56e-4705-97b6-21d6c6c85f06",
+            "blueprint": "tmux-bcl",
+            "version": "1.1.0",
+            "compose_type": "qcow2",
+            "image_size": 0,
+            "queue_status": "RUNNING",
+            "job_created": 1608165945.2225826,
+            "job_started": 1608165945.2256832
+        }
+	]
+}`
+		} else if request.URL.Path == "/api/v1/compose/finished" {
+			json = `{
+	"finished": [
+		{
+			"id": "cefd01c3-629f-493e-af72-3f12981bb77b",  
+            "blueprint": "tmux-bcl",
+            "version": "1.0.0",
+            "compose_type": "qcow2",
+            "image_size": 2147483648,
+            "queue_status": "FINISHED",
+            "job_created": 1608149057.869667,
+            "job_started": 1608149057.8754315,
+            "job_finished": 1608149299.363162
+		}
+	]
+}`
+		} else if request.URL.Path == "/api/v1/compose/failed" {
+			json = `{
+	"failed": [
+		{
+            "id": "d5903571-55e2-4a18-8643-2d90611fcb11",
+            "blueprint": "tmux-bcl",
+            "version": "1.2.0",
+            "compose_type": "qcow2",
+            "image_size": 0,
+            "queue_status": "FAILED",
+            "job_created": 1608166871.5434942,
+            "job_started": 1608166871.5473683,
+            "job_finished": 1608166975.8688467
+		}
+	]
+}`
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// List all of the composes
+	cmd, out, err := root.ExecuteTest("--json", "compose", "list")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"id\": \"b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7\"")
+	assert.Contains(t, string(stdout), "\"id\": \"6d185e04-b56e-4705-97b6-21d6c6c85f06\"")
+	assert.Contains(t, string(stdout), "\"id\": \"cefd01c3-629f-493e-af72-3f12981bb77b\"")
+	assert.Contains(t, string(stdout), "\"id\": \"d5903571-55e2-4a18-8643-2d90611fcb11\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/compose/log.go
+++ b/cmd/composer-cli/compose/log.go
@@ -27,7 +27,7 @@ func init() {
 	composeCmd.AddCommand(logCmd)
 }
 
-func getLog(cmd *cobra.Command, args []string) (rcErr error) {
+func getLog(cmd *cobra.Command, args []string) error {
 	logSize := 1024
 	if len(args) > 1 {
 		s, err := strconv.Atoi(args[1])
@@ -37,14 +37,11 @@ func getLog(cmd *cobra.Command, args []string) (rcErr error) {
 		logSize = s
 	}
 	log, resp, err := root.Client.ComposeLog(args[0], logSize)
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "Log error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "Log error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	fmt.Println(log)

--- a/cmd/composer-cli/compose/logs.go
+++ b/cmd/composer-cli/compose/logs.go
@@ -26,13 +26,13 @@ func init() {
 	composeCmd.AddCommand(logsCmd)
 }
 
-func getLogs(cmd *cobra.Command, args []string) (rcErr error) {
+func getLogs(cmd *cobra.Command, args []string) error {
 	fn, resp, err := root.Client.ComposeLogs(args[0])
 	if err != nil {
 		return root.ExecutionError(cmd, "Logs error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "Logs error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	fmt.Println(fn)

--- a/cmd/composer-cli/compose/logs_test.go
+++ b/cmd/composer-cli/compose/logs_test.go
@@ -69,3 +69,74 @@ And should do the job.`
 	_, err = os.Stat("b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7-logs.tar")
 	assert.Nil(t, err)
 }
+
+func TestCmdComposeLogsUnknown(t *testing.T) {
+	// Test the "compose logs" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+"status":false,
+"errors":[{"id":"UnknownUUID","msg":"4b668b1a-e6b8-4dce-8828-4a8e3bef2345 is not a valid build uuid"}]
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get log from an unknown compose
+	cmd, out, err := root.ExecuteTest("compose", "logs", "4b668b1a-e6b8-4dce-8828-4a8e3bef2345")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, logsCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stderr), "ERROR: UnknownUUID: 4b668b1a-e6b8-4dce-8828-4a8e3bef2345 is not a valid build uuid")
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdComposeLogsUnknownJSON(t *testing.T) {
+	// Test the "compose logs" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+"status":false,
+"errors":[{"id":"UnknownUUID","msg":"4b668b1a-e6b8-4dce-8828-4a8e3bef2345 is not a valid build uuid"}]
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get log from an unknown compose
+	cmd, out, err := root.ExecuteTest("--json", "compose", "logs", "4b668b1a-e6b8-4dce-8828-4a8e3bef2345")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, logsCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"UnknownUUID\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"4b668b1a-e6b8-4dce-8828-4a8e3bef2345 is not a valid build uuid\"")
+	assert.Contains(t, string(stdout), "\"status\": 400")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+}

--- a/cmd/composer-cli/compose/metadata.go
+++ b/cmd/composer-cli/compose/metadata.go
@@ -26,13 +26,13 @@ func init() {
 	composeCmd.AddCommand(metadataCmd)
 }
 
-func getMetadata(cmd *cobra.Command, args []string) (rcErr error) {
+func getMetadata(cmd *cobra.Command, args []string) error {
 	fn, resp, err := root.Client.ComposeMetadata(args[0])
 	if err != nil {
 		return root.ExecutionError(cmd, "Metadata error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "Metadata error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	fmt.Println(fn)

--- a/cmd/composer-cli/compose/results.go
+++ b/cmd/composer-cli/compose/results.go
@@ -26,13 +26,13 @@ func init() {
 	composeCmd.AddCommand(resultsCmd)
 }
 
-func getResults(cmd *cobra.Command, args []string) (rcErr error) {
+func getResults(cmd *cobra.Command, args []string) error {
 	fn, resp, err := root.Client.ComposeResults(args[0])
 	if err != nil {
 		return root.ExecutionError(cmd, "Resultserror: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "Results error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	fmt.Println(fn)

--- a/cmd/composer-cli/compose/results_test.go
+++ b/cmd/composer-cli/compose/results_test.go
@@ -69,3 +69,74 @@ And should do the job.`
 	_, err = os.Stat("b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7.tar")
 	assert.Nil(t, err)
 }
+
+func TestCmdComposeResultsUnknown(t *testing.T) {
+	// Test the "compose results" command with unknown uuid
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+"status":false,
+"errors":[{"id":"UnknownUUID","msg":"b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7 is not a valid build uuid"}]
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get results tar from an unknown compose
+	cmd, out, err := root.ExecuteTest("compose", "results", "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, resultsCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stderr), "UnknownUUID: b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7 is not a valid build uuid")
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdComposeResultsUnknownJSON(t *testing.T) {
+	// Test the "compose results" command with unknown uuid
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+"status":false,
+"errors":[{"id":"UnknownUUID","msg":"b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7 is not a valid build uuid"}]
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get results tar from an unknown compose
+	cmd, out, err := root.ExecuteTest("--json", "compose", "results", "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, resultsCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"UnknownUUID\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7 is not a valid build uuid\"")
+	assert.Contains(t, string(stdout), "\"status\": 400")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+}

--- a/cmd/composer-cli/compose/start.go
+++ b/cmd/composer-cli/compose/start.go
@@ -7,7 +7,6 @@ package compose
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -50,11 +49,8 @@ func start(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return root.ExecutionError(cmd, "Push TOML Error: %s", err)
 	}
-	if root.JSONOutput {
-		return nil
-	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, strings.Join(resp.AllErrors(), "\n"))
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	fmt.Printf("Compose %s added to the queue\n", uuid)

--- a/cmd/composer-cli/compose/start_ostree.go
+++ b/cmd/composer-cli/compose/start_ostree.go
@@ -7,7 +7,6 @@ package compose
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -57,11 +56,8 @@ func startOSTree(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return root.ExecutionError(cmd, "Problem starting OSTree compose: %s", err)
 	}
-	if root.JSONOutput {
-		return nil
-	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, strings.Join(resp.AllErrors(), "\n"))
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	fmt.Printf("Compose %s added to the queue\n", uuid)

--- a/cmd/composer-cli/compose/start_ostree_test.go
+++ b/cmd/composer-cli/compose/start_ostree_test.go
@@ -39,6 +39,7 @@ func TestCmdComposeStartOSTree(t *testing.T) {
 
 	// Start a compose
 	cmd, out, err := root.ExecuteTest("compose", "start-ostree", "--ref", "refid", "--parent", "parentid", "http-server", "qcow2")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, cmd)
@@ -56,6 +57,158 @@ func TestCmdComposeStartOSTree(t *testing.T) {
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"parentid","url":""}}`), sentBody)
+	assert.Equal(t, "application/json", mc.Req.Header.Get("Content-Type"))
+	assert.Equal(t, "/api/v1/compose", mc.Req.URL.Path)
+}
+
+func TestCmdComposeStartOSTreeJSON(t *testing.T) {
+	// Test the "compose start-ostree" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+			"build_id": "876b2946-16cd-4f38-bace-0cdd0093d112",
+			"status": true
+}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Make sure the optional command values are reset to their defaults
+	size = 0
+	ref = ""
+	parent = ""
+	url = ""
+
+	// Start a compose
+	cmd, out, err := root.ExecuteTest("--json", "compose", "start-ostree", "--ref", "refid", "--parent", "parentid", "http-server", "qcow2")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, startOSTreeCmd)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": true")
+	assert.Contains(t, string(stdout), "\"build_id\": \"876b2946-16cd-4f38-bace-0cdd0093d112\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/compose\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "POST", mc.Req.Method)
+	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	mc.Req.Body.Close()
+	require.Nil(t, err)
+	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"parentid","url":""}}`), sentBody)
+	assert.Equal(t, "application/json", mc.Req.Header.Get("Content-Type"))
+	assert.Equal(t, "/api/v1/compose", mc.Req.URL.Path)
+}
+
+func TestCmdComposeStartOSTreeUnknown(t *testing.T) {
+	// Test the "compose start-ostree" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+		"errors": [
+            {
+                "id": "UnknownBlueprint",
+                "msg": "Unknown blueprint name: missing-server"
+            }
+        ],
+		"status":false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Make sure the optional command values are reset to their defaults
+	size = 0
+	ref = ""
+	parent = ""
+	url = ""
+
+	// Start a compose
+	cmd, out, err := root.ExecuteTest("compose", "start-ostree", "--ref", "refid", "--parent", "parentid", "missing-server", "qcow2")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, startOSTreeCmd)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stderr), "UnknownBlueprint: Unknown blueprint name: missing-server")
+	assert.Equal(t, "POST", mc.Req.Method)
+	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	mc.Req.Body.Close()
+	require.Nil(t, err)
+	assert.Equal(t, []byte(`{"blueprint_name":"missing-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"parentid","url":""}}`), sentBody)
+	assert.Equal(t, "application/json", mc.Req.Header.Get("Content-Type"))
+	assert.Equal(t, "/api/v1/compose", mc.Req.URL.Path)
+}
+
+func TestCmdComposeStartOSTreeUnknownJSON(t *testing.T) {
+	// Test the "compose start-ostree" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+		"errors": [
+            {
+                "id": "UnknownBlueprint",
+                "msg": "Unknown blueprint name: missing-server"
+            }
+        ],
+		"status":false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Make sure the optional command values are reset to their defaults
+	size = 0
+	ref = ""
+	parent = ""
+	url = ""
+
+	// Start a compose
+	cmd, out, err := root.ExecuteTest("--json", "compose", "start-ostree", "--ref", "refid", "--parent", "parentid", "missing-server", "qcow2")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, startOSTreeCmd)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"UnknownBlueprint\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"Unknown blueprint name: missing-server\"")
+	assert.Contains(t, string(stdout), "\"status\": 400")
+	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/compose\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "POST", mc.Req.Method)
+	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	mc.Req.Body.Close()
+	require.Nil(t, err)
+	assert.Equal(t, []byte(`{"blueprint_name":"missing-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"parentid","url":""}}`), sentBody)
 	assert.Equal(t, "application/json", mc.Req.Header.Get("Content-Type"))
 	assert.Equal(t, "/api/v1/compose", mc.Req.URL.Path)
 }
@@ -82,6 +235,7 @@ func TestCmdComposeStartOSTreeURL(t *testing.T) {
 
 	// Start a compose
 	cmd, out, err := root.ExecuteTest("compose", "start-ostree", "--ref", "refid", "--url", "http://ostree-url", "http-server", "qcow2")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, cmd)
@@ -99,6 +253,110 @@ func TestCmdComposeStartOSTreeURL(t *testing.T) {
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"","url":"http://ostree-url"}}`), sentBody)
+	assert.Equal(t, "application/json", mc.Req.Header.Get("Content-Type"))
+	assert.Equal(t, "/api/v1/compose", mc.Req.URL.Path)
+}
+
+func TestCmdComposeStartOSTreeURLUnknown(t *testing.T) {
+	// Test the "compose start-ostree" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+        "errors": [
+            {
+                "id": "OSTreeCommitError",
+                "msg": "Get \"http://nowhere/refs/heads/refid\": dial tcp: lookup nowhere: no such host"
+            }
+        ],
+        "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Make sure the optional command values are reset to their defaults
+	size = 0
+	ref = ""
+	parent = ""
+	url = ""
+
+	// Start a compose
+	cmd, out, err := root.ExecuteTest("compose", "start-ostree", "--ref", "refid", "--url", "http://not-ostree-url", "http-server", "qcow2")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, startOSTreeCmd)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stderr), "OSTreeCommitError: ")
+	assert.Equal(t, "POST", mc.Req.Method)
+	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	mc.Req.Body.Close()
+	require.Nil(t, err)
+	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"","url":"http://not-ostree-url"}}`), sentBody)
+	assert.Equal(t, "application/json", mc.Req.Header.Get("Content-Type"))
+	assert.Equal(t, "/api/v1/compose", mc.Req.URL.Path)
+}
+
+func TestCmdComposeStartOSTreeURLUnknownJSON(t *testing.T) {
+	// Test the "compose start-ostree" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+        "errors": [
+            {
+                "id": "OSTreeCommitError",
+                "msg": "Get \"http://nowhere/refs/heads/refid\": dial tcp: lookup nowhere: no such host"
+            }
+        ],
+        "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Make sure the optional command values are reset to their defaults
+	size = 0
+	ref = ""
+	parent = ""
+	url = ""
+
+	// Start a compose
+	cmd, out, err := root.ExecuteTest("--json", "compose", "start-ostree", "--ref", "refid", "--url", "http://not-ostree-url", "http-server", "qcow2")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, startOSTreeCmd)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"OSTreeCommitError\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/compose\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "POST", mc.Req.Method)
+	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	mc.Req.Body.Close()
+	require.Nil(t, err)
+	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"","url":"http://not-ostree-url"}}`), sentBody)
 	assert.Equal(t, "application/json", mc.Req.Header.Get("Content-Type"))
 	assert.Equal(t, "/api/v1/compose", mc.Req.URL.Path)
 }
@@ -125,6 +383,7 @@ func TestCmdComposeStartOSTreeSize(t *testing.T) {
 
 	// Start a compose
 	cmd, out, err := root.ExecuteTest("compose", "start-ostree", "--size", "998", "--ref", "refid", "--parent", "parentid", "http-server", "qcow2")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, cmd)
@@ -182,6 +441,7 @@ aws_secret_key = "AWS Secret Key"
 
 	// Start a compose
 	cmd, out, err := root.ExecuteTest("compose", "start-ostree", "--ref", "refid", "--parent", "parentid", "http-server", "qcow2", "httpimage", tmpProfile.Name())
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, cmd)
@@ -201,4 +461,33 @@ aws_secret_key = "AWS Secret Key"
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"parentid","url":""},"upload":{"provider":"aws","image_name":"httpimage","settings":{"aws_access_key":"AWS Access Key","aws_bucket":"AWS Bucket","aws_region":"AWS Region","aws_secret_key":"AWS Secret Key"}}}`), sentBody)
 	assert.Equal(t, "application/json", mc.Req.Header.Get("Content-Type"))
 	assert.Equal(t, "/api/v1/compose", mc.Req.URL.Path)
+}
+
+func TestCmdComposeStartOSTreeUploadUnknown(t *testing.T) {
+	// Test the "compose start" command with upload
+
+	// NOTE: No mock client needed here, it fails before making the request
+
+	// Make sure the optional command values are reset to their defaults
+	size = 0
+	ref = ""
+	parent = ""
+	url = ""
+
+	// Start a compose
+	cmd, out, err := root.ExecuteTest("compose", "start-ostree", "--ref", "refid", "--parent", "parentid", "http-server", "qcow2", "httpimage", "/path/to/missing.file")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, "Problem starting OSTree compose: open /path/to/missing.file: no such file or directory"), err)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, startOSTreeCmd)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 }

--- a/cmd/composer-cli/compose/status.go
+++ b/cmd/composer-cli/compose/status.go
@@ -6,7 +6,6 @@ package compose
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -31,17 +30,11 @@ func init() {
 
 func status(cmd *cobra.Command, args []string) (rcErr error) {
 	composes, errors, err := root.Client.ListComposes()
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "List Error: %s", err)
 	}
 	if len(errors) > 0 {
-		for _, e := range errors {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", e.String())
-		}
-		rcErr = root.ExecutionError(cmd, "")
+		rcErr = root.ExecutionErrors(cmd, errors)
 	}
 
 	composes = weldr.SortComposeStatusV0(composes)

--- a/cmd/composer-cli/compose/status_test.go
+++ b/cmd/composer-cli/compose/status_test.go
@@ -99,6 +99,7 @@ func TestCmdComposeStatus(t *testing.T) {
 
 	// List the status of all of the composes
 	cmd, out, err := root.ExecuteTest("compose", "status")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -117,6 +118,111 @@ func TestCmdComposeStatus(t *testing.T) {
 
 		assert.Contains(t, string(stdout), s)
 	}
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdComposeStatusJSON(t *testing.T) {
+	// Test the "compose status" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		var json string
+		if request.URL.Path == "/api/v1/compose/queue" {
+			json = `{
+	"new": [
+		{
+			"id": "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7",
+			"blueprint": "tmux-bcl",
+			"version": "1.1.0",
+			"compose_type": "qcow2",
+			"image_size": 0,
+			"queue_status": "WAITING",
+			"job_created": 1608165958.8658934
+		}
+    ],
+    "run": [
+        {
+            "id": "6d185e04-b56e-4705-97b6-21d6c6c85f06",
+            "blueprint": "tmux-bcl",
+            "version": "1.1.0",
+            "compose_type": "qcow2",
+            "image_size": 0,
+            "queue_status": "RUNNING",
+            "job_created": 1608165945.2225826,
+            "job_started": 1608165945.2256832
+        }
+	]
+}`
+		} else if request.URL.Path == "/api/v1/compose/finished" {
+			json = `{
+	"finished": [
+		{
+			"id": "cefd01c3-629f-493e-af72-3f12981bb77b",  
+            "blueprint": "tmux-bcl",
+            "version": "1.2.0",
+            "compose_type": "qcow2",
+            "image_size": 2147483648,
+            "queue_status": "FINISHED",
+            "job_created": 1608149057.869667,
+            "job_started": 1608149057.8754315,
+            "job_finished": 1608149299.363162
+		},
+		{
+			"id": "848b6d9f-9bc3-41e1-ae33-5907ad61af76",  
+            "blueprint": "tmux-bcl",
+            "version": "1.0.0",
+            "compose_type": "qcow2",
+            "image_size": 2147483648,
+            "queue_status": "FINISHED",
+            "job_created": 1608149057.869667,
+            "job_started": 1608149057.8754315,
+            "job_finished": 1608149299.363162
+		}
+	]
+}`
+		} else if request.URL.Path == "/api/v1/compose/failed" {
+			json = `{
+	"failed": [
+		{
+            "id": "d5903571-55e2-4a18-8643-2d90611fcb11",
+            "blueprint": "tmux-bcl",
+            "version": "1.2.0",
+            "compose_type": "qcow2",
+            "image_size": 0,
+            "queue_status": "FAILED",
+            "job_created": 1608166871.5434942,
+            "job_started": 1608166871.5473683,
+            "job_finished": 1608166975.8688467
+		}
+	]
+}`
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// List the status of all of the composes
+	cmd, out, err := root.ExecuteTest("--json", "compose", "status")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, statusCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"id\": \"6d185e04-b56e-4705-97b6-21d6c6c85f06\"")
+	assert.Contains(t, string(stdout), "\"id\": \"b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7\"")
+	assert.Contains(t, string(stdout), "\"id\": \"848b6d9f-9bc3-41e1-ae33-5907ad61af76\"")
+	assert.Contains(t, string(stdout), "\"id\": \"d5903571-55e2-4a18-8643-2d90611fcb11\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/compose/queue\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/compose/finished\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/compose/failed\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)

--- a/cmd/composer-cli/compose/types.go
+++ b/cmd/composer-cli/compose/types.go
@@ -31,14 +31,11 @@ func init() {
 
 func types(cmd *cobra.Command, args []string) error {
 	types, resp, err := root.Client.GetComposeTypes(distro)
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "Types Error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "Types Error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	sort.Strings(types)

--- a/cmd/composer-cli/distros/list.go
+++ b/cmd/composer-cli/distros/list.go
@@ -28,14 +28,11 @@ func init() {
 
 func list(cmd *cobra.Command, args []string) error {
 	distros, resp, err := root.Client.ListDistros()
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "Types Error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "Types Error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	for _, name := range distros {

--- a/cmd/composer-cli/distros/list_test.go
+++ b/cmd/composer-cli/distros/list_test.go
@@ -29,6 +29,7 @@ func TestCmdDistrosList(t *testing.T) {
 
 	// Get the list of distros
 	cmd, out, err := root.ExecuteTest("distros", "list")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -37,7 +38,40 @@ func TestCmdDistrosList(t *testing.T) {
 	assert.Equal(t, cmd, listCmd)
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
-	assert.NotEqual(t, []byte(""), stdout)
+	assert.NotContains(t, string(stdout), "{")
+	assert.Contains(t, string(stdout), "centos-8")
+	assert.Contains(t, string(stdout), "fedora-33")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdDistrosListJSON(t *testing.T) {
+	// Test the "distros list" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{"distros":["centos-8","fedora-32","fedora-33","rhel-8"]}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get the list of distros
+	cmd, out, err := root.ExecuteTest("--json", "distros", "list")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "{")
+	assert.Contains(t, string(stdout), "\"centos-8\"")
+	assert.Contains(t, string(stdout), "\"fedora-33\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)

--- a/cmd/composer-cli/modules/info.go
+++ b/cmd/composer-cli/modules/info.go
@@ -6,7 +6,6 @@ package modules
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -32,14 +31,11 @@ func info(cmd *cobra.Command, args []string) error {
 	names := root.GetCommaArgs(args)
 
 	modules, resp, err := root.Client.ModulesInfo(names, distro)
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "Info Error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, strings.Join(resp.AllErrors(), "\n"))
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	for _, p := range modules {

--- a/cmd/composer-cli/modules/info_test.go
+++ b/cmd/composer-cli/modules/info_test.go
@@ -76,7 +76,9 @@ func TestCmdModulesInfo(t *testing.T) {
 		}, nil
 	})
 
+	distro = ""
 	cmd, out, err := root.ExecuteTest("modules", "info", "bash")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -94,6 +96,170 @@ func TestCmdModulesInfo(t *testing.T) {
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
 	assert.Equal(t, "/api/v1/modules/info/bash", mc.Req.URL.Path)
+}
+
+func TestCmdModulesInfoJSON(t *testing.T) {
+	// Test the "modules info" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "modules": [
+        {
+            "builds": [
+                {
+                    "arch": "x86_64",
+                    "build_config_ref": "BUILD_CONFIG_REF",
+                    "build_env_ref": "BUILD_ENV_REF",
+                    "build_time": "2020-07-27T13:17:35",
+                    "changelog": "CHANGELOG_NEEDED",
+                    "epoch": 0,
+                    "metadata": {},
+                    "release": "2.fc33",
+                    "source": {
+                        "license": "GPLv3+",
+                        "metadata": {},
+                        "source_ref": "SOURCE_REF",
+                        "version": "5.0.17"
+                    }
+                }
+            ],
+            "dependencies": [
+                {
+                    "arch": "noarch",
+                    "check_gpg": true,
+                    "checksum": "sha256:f4efaa5bc8382246d8230ece8bacebd3c29eb9fd52b509b1e6575e643953851b",
+                    "epoch": 0,
+                    "name": "basesystem",
+                    "release": "10.fc33",
+                    "remote_location": "http://mirror.web-ster.com/fedora/releases/33/Everything/x86_64/os/Packages/b/basesystem-11-10.fc33.noarch.rpm",
+                    "version": "11"
+                },
+                {
+                    "arch": "x86_64",
+                    "check_gpg": true,
+                    "checksum": "sha256:c59a621f3cdd5e073b3c1ef9cd8fd9d7e02d77d94be05330390eac05f77b5b60",
+                    "epoch": 0,
+                    "name": "bash",
+                    "release": "2.fc33",
+                    "remote_location": "http://mirror.web-ster.com/fedora/releases/33/Everything/x86_64/os/Packages/b/bash-5.0.17-2.fc33.x86_64.rpm",
+                    "version": "5.0.17"
+                }
+            ],
+            "description": "The GNU Bourne Again shell (Bash) is a shell or command language\ninterpreter that is compatible with the Bourne shell (sh). Bash\nincorporates useful features from the Korn shell (ksh) and the C shell\n(csh). Most sh scripts can be run by bash without modification.",
+            "homepage": "https://www.gnu.org/software/bash",
+            "name": "bash",
+            "summary": "The GNU Bourne Again shell",
+            "upstream_vcs": "UPSTREAM_VCS"
+        }
+    ]}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "modules", "info", "bash")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, infoCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"description\": \"The GNU Bourne Again shell")
+	assert.Contains(t, string(stdout), "\"version\": \"5.0.17\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/modules/info/bash\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/info/bash", mc.Req.URL.Path)
+}
+
+func TestCmdModulesInfoUnknown(t *testing.T) {
+	// Test the "modules info" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+        "errors": [
+            {
+                "id": "UnknownModule",
+                "msg": "No packages have been found."
+            }
+        ],
+        "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("modules", "info", "mash")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, infoCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stderr), "UnknownModule: No packages have been found")
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/info/mash", mc.Req.URL.Path)
+}
+
+func TestCmdModulesInfoUnknownJSON(t *testing.T) {
+	// Test the "modules info" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+        "errors": [
+            {
+                "id": "UnknownModule",
+                "msg": "No packages have been found."
+            }
+        ],
+        "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "modules", "info", "mash")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, infoCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"UnknownModule\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"No packages have been found.\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/modules/info/mash\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/info/mash", mc.Req.URL.Path)
 }
 
 func TestCmdModulesInfoDistro(t *testing.T) {
@@ -156,7 +322,9 @@ func TestCmdModulesInfoDistro(t *testing.T) {
 		}, nil
 	})
 
+	distro = ""
 	cmd, out, err := root.ExecuteTest("modules", "info", "--distro=test-distro", "bash")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -169,6 +337,87 @@ func TestCmdModulesInfoDistro(t *testing.T) {
 	assert.Contains(t, string(stdout), "             shell (sh). Bash")
 	assert.Contains(t, string(stdout), "     5.0.17-2.fc33.x86_64 at")
 	assert.Contains(t, string(stdout), "     basesystem-11-10.fc33.noarch")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/info/bash", mc.Req.URL.Path)
+}
+
+func TestCmdModulesInfoDistroJSON(t *testing.T) {
+	// Test the "modules info --distro=test-distro" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "modules": [
+        {
+            "builds": [
+                {
+                    "arch": "x86_64",
+                    "build_config_ref": "BUILD_CONFIG_REF",
+                    "build_env_ref": "BUILD_ENV_REF",
+                    "build_time": "2020-07-27T13:17:35",
+                    "changelog": "CHANGELOG_NEEDED",
+                    "epoch": 0,
+                    "metadata": {},
+                    "release": "2.fc33",
+                    "source": {
+                        "license": "GPLv3+",
+                        "metadata": {},
+                        "source_ref": "SOURCE_REF",
+                        "version": "5.0.17"
+                    }
+                }
+            ],
+            "dependencies": [
+                {
+                    "arch": "noarch",
+                    "check_gpg": true,
+                    "checksum": "sha256:f4efaa5bc8382246d8230ece8bacebd3c29eb9fd52b509b1e6575e643953851b",
+                    "epoch": 0,
+                    "name": "basesystem",
+                    "release": "10.fc33",
+                    "remote_location": "http://mirror.web-ster.com/fedora/releases/33/Everything/x86_64/os/Packages/b/basesystem-11-10.fc33.noarch.rpm",
+                    "version": "11"
+                },
+                {
+                    "arch": "x86_64",
+                    "check_gpg": true,
+                    "checksum": "sha256:c59a621f3cdd5e073b3c1ef9cd8fd9d7e02d77d94be05330390eac05f77b5b60",
+                    "epoch": 0,
+                    "name": "bash",
+                    "release": "2.fc33",
+                    "remote_location": "http://mirror.web-ster.com/fedora/releases/33/Everything/x86_64/os/Packages/b/bash-5.0.17-2.fc33.x86_64.rpm",
+                    "version": "5.0.17"
+                }
+            ],
+            "description": "The GNU Bourne Again shell (Bash) is a shell or command language\ninterpreter that is compatible with the Bourne shell (sh). Bash\nincorporates useful features from the Korn shell (ksh) and the C shell\n(csh). Most sh scripts can be run by bash without modification.",
+            "homepage": "https://www.gnu.org/software/bash",
+            "name": "bash",
+            "summary": "The GNU Bourne Again shell",
+            "upstream_vcs": "UPSTREAM_VCS"
+        }
+    ]}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "modules", "info", "--distro=test-distro", "bash")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, infoCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"description\": \"The GNU Bourne Again shell")
+	assert.Contains(t, string(stdout), "\"version\": \"5.0.17\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/modules/info/bash?distro=test-distro\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -197,7 +446,9 @@ func TestCmdModulesInfoBadDistro(t *testing.T) {
 	})
 
 	// Get the compose types
+	distro = ""
 	cmd, out, err := root.ExecuteTest("modules", "info", "--distro=homer", "bash")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -210,5 +461,47 @@ func TestCmdModulesInfoBadDistro(t *testing.T) {
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "DistroError: Invalid distro: homer")
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdModulesInfoBadDistroJSON(t *testing.T) {
+	// Test the "modules info --distro=homer" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+        "errors": [
+            {
+                "id": "DistroError",
+                "msg": "Invalid distro: homer"
+            }
+        ],
+        "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get the compose types
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "modules", "info", "--distro=homer", "bash")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, infoCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"DistroError\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"Invalid distro: homer\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/modules/info/bash?distro=homer\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
 }

--- a/cmd/composer-cli/modules/list.go
+++ b/cmd/composer-cli/modules/list.go
@@ -29,14 +29,11 @@ func init() {
 
 func list(cmd *cobra.Command, args []string) error {
 	modules, resp, err := root.Client.ListModules(distro)
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "List Error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "List Error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	for i := range modules {

--- a/cmd/composer-cli/modules/list_test.go
+++ b/cmd/composer-cli/modules/list_test.go
@@ -39,7 +39,9 @@ func TestCmdModulesList(t *testing.T) {
 		}, nil
 	})
 
+	distro = ""
 	cmd, out, err := root.ExecuteTest("modules", "list")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -50,6 +52,49 @@ func TestCmdModulesList(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "http-server-prod")
 	assert.Contains(t, string(stdout), "nfs-server-test")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/list", mc.Req.URL.Path)
+}
+
+func TestCmdModulesListJSON(t *testing.T) {
+	// Test the "modules list" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		var json string
+		if limit == 0 {
+			json = `{"modules": [], "total": 2, "offset": 0, "limit": 0}`
+		} else {
+			json = `{"modules": [
+						{"name":"http-server-prod", "group_type":"rpm"},
+						{"name":"nfs-server-test", "group_type":"rpm"}],
+					"total": 2, "offset": 0, "limit": 2}`
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "modules", "list")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"name\": \"http-server-prod\"")
+	assert.Contains(t, string(stdout), "\"name\": \"nfs-server-test\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/modules/list?limit=0\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -79,7 +124,9 @@ func TestCmdModulesListDistro(t *testing.T) {
 		}, nil
 	})
 
+	distro = ""
 	cmd, out, err := root.ExecuteTest("modules", "list", "--distro=test-distro")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -90,6 +137,49 @@ func TestCmdModulesListDistro(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "http-server-prod")
 	assert.Contains(t, string(stdout), "nfs-server-test")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/list", mc.Req.URL.Path)
+}
+
+func TestCmdModulesListDistroJSON(t *testing.T) {
+	// Test the "modules list --distro=test-distro" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		var json string
+		if limit == 0 {
+			json = `{"modules": [], "total": 2, "offset": 0, "limit": 0}`
+		} else {
+			json = `{"modules": [
+						{"name":"http-server-prod", "group_type":"rpm"},
+						{"name":"nfs-server-test", "group_type":"rpm"}],
+					"total": 2, "offset": 0, "limit": 2}`
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "modules", "list", "--distro=test-distro")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"name\": \"http-server-prod\"")
+	assert.Contains(t, string(stdout), "\"name\": \"nfs-server-test\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/modules/list?distro=test-distro\\u0026limit=0\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -118,7 +208,9 @@ func TestCmdModulesListBadDistro(t *testing.T) {
 	})
 
 	// Get the compose types
+	distro = ""
 	cmd, out, err := root.ExecuteTest("modules", "list", "--distro=homer")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -131,5 +223,47 @@ func TestCmdModulesListBadDistro(t *testing.T) {
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "DistroError: Invalid distro: homer")
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdModulesListBadDistroJSON(t *testing.T) {
+	// Test the "modules list --distro=homer" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+        "errors": [
+            {
+                "id": "DistroError",
+                "msg": "Invalid distro: homer"
+            }
+        ],
+        "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get the compose types
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "modules", "list", "--distro=homer")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"DistroError\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"Invalid distro: homer\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/modules/list?distro=homer\\u0026limit=0\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
 }

--- a/cmd/composer-cli/projects/depsolve.go
+++ b/cmd/composer-cli/projects/depsolve.go
@@ -52,14 +52,8 @@ func depsolve(cmd *cobra.Command, args []string) (rcErr error) {
 	if err != nil {
 		return root.ExecutionError(cmd, "Depsolve Error: %s", err)
 	}
-	if root.JSONOutput {
-		return nil
-	}
 	if len(errors) > 0 {
-		for _, e := range errors {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", e.String())
-		}
-		rcErr = root.ExecutionError(cmd, "")
+		rcErr = root.ExecutionErrors(cmd, errors)
 	}
 
 	// Encode it using json

--- a/cmd/composer-cli/projects/depsolve_test.go
+++ b/cmd/composer-cli/projects/depsolve_test.go
@@ -49,6 +49,7 @@ func TestCmdProjectsDepsolve(t *testing.T) {
 	})
 
 	cmd, out, err := root.ExecuteTest("projects", "depsolve", "bash")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -57,8 +58,60 @@ func TestCmdProjectsDepsolve(t *testing.T) {
 	assert.Equal(t, cmd, depsolveCmd)
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
+	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "acl-2.2.53-9.fc33.x86_64")
 	assert.Contains(t, string(stdout), "basesystem-11-10.fc33.noarch")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdProjectsDepsolveJSON(t *testing.T) {
+	// Test the "projects depsolve" command
+	json := `{
+		"projects": [
+            {
+                "arch": "x86_64",
+                "check_gpg": true,
+                "checksum": "sha256:92c1615d385b32088f78a6574a2bf89a6bb29d9858abdd71471ef5113ef0831f",
+                "epoch": 0,
+                "name": "acl",
+                "release": "9.fc33",
+                "remote_location": "https://mirrors.rit.edu/fedora/fedora/linux/releases/33/Everything/x86_64/os/Packages/a/acl-2.2.53-9.fc33.x86_64.rpm",
+                "version": "2.2.53"
+            },
+            {
+                "arch": "noarch",
+                "check_gpg": true,
+                "checksum": "sha256:f4efaa5bc8382246d8230ece8bacebd3c29eb9fd52b509b1e6575e643953851b",
+                "epoch": 0,
+                "name": "basesystem",
+                "release": "10.fc33",
+                "remote_location": "https://mirrors.rit.edu/fedora/fedora/linux/releases/33/Everything/x86_64/os/Packages/b/basesystem-11-10.fc33.noarch.rpm",
+                "version": "11"
+            }
+	]}`
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "projects", "depsolve", "bash")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, depsolveCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"name\": \"basesystem\"")
+	assert.Contains(t, string(stdout), "\"version\": \"2.2.53\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/projects/depsolve/bash\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -98,6 +151,7 @@ func TestCmdProjectsDepsolveDistro(t *testing.T) {
 	})
 
 	cmd, out, err := root.ExecuteTest("projects", "depsolve", "--distro=test-distro", "bash")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -106,8 +160,60 @@ func TestCmdProjectsDepsolveDistro(t *testing.T) {
 	assert.Equal(t, cmd, depsolveCmd)
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
+	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "acl-2.2.53-9.fc33.x86_64")
 	assert.Contains(t, string(stdout), "basesystem-11-10.fc33.noarch")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdProjectsDepsolveDistroJSON(t *testing.T) {
+	// Test the "projects depsolve --distro=test-distro" command
+	json := `{
+		"projects": [
+            {
+                "arch": "x86_64",
+                "check_gpg": true,
+                "checksum": "sha256:92c1615d385b32088f78a6574a2bf89a6bb29d9858abdd71471ef5113ef0831f",
+                "epoch": 0,
+                "name": "acl",
+                "release": "9.fc33",
+                "remote_location": "https://mirrors.rit.edu/fedora/fedora/linux/releases/33/Everything/x86_64/os/Packages/a/acl-2.2.53-9.fc33.x86_64.rpm",
+                "version": "2.2.53"
+            },
+            {
+                "arch": "noarch",
+                "check_gpg": true,
+                "checksum": "sha256:f4efaa5bc8382246d8230ece8bacebd3c29eb9fd52b509b1e6575e643953851b",
+                "epoch": 0,
+                "name": "basesystem",
+                "release": "10.fc33",
+                "remote_location": "https://mirrors.rit.edu/fedora/fedora/linux/releases/33/Everything/x86_64/os/Packages/b/basesystem-11-10.fc33.noarch.rpm",
+                "version": "11"
+            }
+	]}`
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "projects", "depsolve", "--distro=test-distro", "bash")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, depsolveCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"name\": \"basesystem\"")
+	assert.Contains(t, string(stdout), "\"version\": \"2.2.53\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/projects/depsolve/bash?distro=test-distro\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -136,6 +242,7 @@ func TestCmdProjectsDepsolveBadDistro(t *testing.T) {
 
 	// Get the compose types
 	cmd, out, err := root.ExecuteTest("projects", "depsolve", "--distro=homer", "bash")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -148,6 +255,47 @@ func TestCmdProjectsDepsolveBadDistro(t *testing.T) {
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "DistroError: Invalid distro: homer")
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdProjectsDepsolveBadDistroJSON(t *testing.T) {
+	// Test the "projects depsolve --distro=homer" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+        "errors": [
+            {
+                "id": "DistroError",
+                "msg": "Invalid distro: homer"
+            }
+        ],
+        "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get the compose types
+	cmd, out, err := root.ExecuteTest("--json", "projects", "depsolve", "--distro=homer", "bash")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, depsolveCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"DistroError\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"Invalid distro: homer\"")
+	assert.Contains(t, string(stdout), "\"status\": 400")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
 }
 
@@ -164,12 +312,14 @@ func TestCmdProjectsDepsolveUnknown(t *testing.T) {
 	}`
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
-			StatusCode: 200,
+			Request:    request,
+			StatusCode: 400,
 			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	cmd, out, err := root.ExecuteTest("projects", "depsolve", "bash,homer")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
 	assert.Equal(t, root.ExecutionError(cmd, ""), err)
@@ -183,5 +333,45 @@ func TestCmdProjectsDepsolveUnknown(t *testing.T) {
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "missing packages: homer")
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdProjectsDepsolveUnknownJSON(t *testing.T) {
+	// Test the "projects depsolve" command with an unknown package
+	json := `{
+        "errors": [
+            {
+                "id": "ProjectsError",
+                "msg": "BadRequest: DNF error occured: MarkingErrors: Error occurred when marking packages for installation: Problems in request:\nmissing packages: homer"
+            }
+        ],
+        "status": false
+	}`
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "projects", "depsolve", "bash,homer")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, depsolveCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"ProjectsError\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"BadRequest: DNF error occured")
+	assert.Contains(t, string(stdout), "\"status\": 400")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
 }

--- a/cmd/composer-cli/projects/info.go
+++ b/cmd/composer-cli/projects/info.go
@@ -6,7 +6,6 @@ package projects
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -32,14 +31,11 @@ func info(cmd *cobra.Command, args []string) error {
 	names := root.GetCommaArgs(args)
 
 	projects, resp, err := root.Client.ProjectsInfo(names, distro)
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "Info Error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, strings.Join(resp.AllErrors(), "\n"))
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	for _, p := range projects {

--- a/cmd/composer-cli/projects/info_test.go
+++ b/cmd/composer-cli/projects/info_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestCmdProjectsInfo(t *testing.T) {
-	// Test the "modules list" command
+	// Test the "projects info" command
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		json := `{
     "projects": [
@@ -54,6 +54,7 @@ func TestCmdProjectsInfo(t *testing.T) {
 		}, nil
 	})
 
+	distro = ""
 	cmd, out, err := root.ExecuteTest("projects", "info", "bash")
 	defer out.Close()
 	require.Nil(t, err)
@@ -73,8 +74,8 @@ func TestCmdProjectsInfo(t *testing.T) {
 	assert.Equal(t, "/api/v1/projects/info/bash", mc.Req.URL.Path)
 }
 
-func TestCmdProjectsInfoDistro(t *testing.T) {
-	// Test the "modules info --distro=test-distro" command
+func TestCmdProjectsInfoJSON(t *testing.T) {
+	// Test the "projects info" command
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		json := `{
     "projects": [
@@ -111,6 +112,148 @@ func TestCmdProjectsInfoDistro(t *testing.T) {
 		}, nil
 	})
 
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "projects", "info", "bash")
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, infoCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"description\": \"The GNU Bourne Again shell")
+	assert.Contains(t, string(stdout), "\"version\": \"5.0.17\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/projects/info/bash\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/projects/info/bash", mc.Req.URL.Path)
+}
+
+func TestCmdModulesInfoUnknown(t *testing.T) {
+	// Test the "projects info" command with an unknown project
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+        "errors": [
+            {
+                "id": "UnknownProject",
+                "msg": "No packages have been found."
+            }
+        ],
+        "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("projects", "info", "mash")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, infoCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stderr), "UnknownProject: No packages have been found")
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/projects/info/mash", mc.Req.URL.Path)
+}
+
+func TestCmdModulesInfoUnknownJSON(t *testing.T) {
+	// Test the "projects info" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+        "errors": [
+            {
+                "id": "UnknownProject",
+                "msg": "No packages have been found."
+            }
+        ],
+        "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "projects", "info", "mash")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	assert.Equal(t, root.ExecutionError(cmd, ""), err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, infoCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"UnknownProject\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"No packages have been found.\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/projects/info/mash\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/projects/info/mash", mc.Req.URL.Path)
+}
+
+func TestCmdProjectsInfoDistro(t *testing.T) {
+	// Test the "projects info --distro=test-distro" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "projects": [
+        {
+            "builds": [
+                {
+                    "arch": "x86_64",
+                    "build_config_ref": "BUILD_CONFIG_REF",
+                    "build_env_ref": "BUILD_ENV_REF",
+                    "build_time": "2020-07-27T13:17:35",
+                    "changelog": "CHANGELOG_NEEDED",
+                    "epoch": 0,
+                    "metadata": {},
+                    "release": "2.fc33",
+                    "source": {
+                        "license": "GPLv3+",
+                        "metadata": {},
+                        "source_ref": "SOURCE_REF",
+                        "version": "5.0.17"
+                    }
+                }
+            ],
+            "description": "The GNU Bourne Again shell (Bash) is a shell or command language\ninterpreter that is compatible with the Bourne shell (sh). Bash\nincorporates useful features from the Korn shell (ksh) and the C shell\n(csh). Most sh scripts can be run by bash without modification.",
+            "homepage": "https://www.gnu.org/software/bash",
+            "name": "bash",
+            "summary": "The GNU Bourne Again shell",
+            "upstream_vcs": "UPSTREAM_VCS"
+        }
+    ]}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
 	cmd, out, err := root.ExecuteTest("projects", "info", "--distro=test-distro", "bash")
 	defer out.Close()
 	require.Nil(t, err)
@@ -123,6 +266,64 @@ func TestCmdProjectsInfoDistro(t *testing.T) {
 	assert.Contains(t, string(stdout), "Summary: The GNU Bourne Again shell")
 	assert.Contains(t, string(stdout), "             shell (sh). Bash")
 	assert.Contains(t, string(stdout), "     5.0.17-2.fc33.x86_64 at")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/projects/info/bash", mc.Req.URL.Path)
+}
+
+func TestCmdProjectsInfoDistroJSON(t *testing.T) {
+	// Test the "projects info --distro=test-distro" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "projects": [
+        {
+            "builds": [
+                {
+                    "arch": "x86_64",
+                    "build_config_ref": "BUILD_CONFIG_REF",
+                    "build_env_ref": "BUILD_ENV_REF",
+                    "build_time": "2020-07-27T13:17:35",
+                    "changelog": "CHANGELOG_NEEDED",
+                    "epoch": 0,
+                    "metadata": {},
+                    "release": "2.fc33",
+                    "source": {
+                        "license": "GPLv3+",
+                        "metadata": {},
+                        "source_ref": "SOURCE_REF",
+                        "version": "5.0.17"
+                    }
+                }
+            ],
+            "description": "The GNU Bourne Again shell (Bash) is a shell or command language\ninterpreter that is compatible with the Bourne shell (sh). Bash\nincorporates useful features from the Korn shell (ksh) and the C shell\n(csh). Most sh scripts can be run by bash without modification.",
+            "homepage": "https://www.gnu.org/software/bash",
+            "name": "bash",
+            "summary": "The GNU Bourne Again shell",
+            "upstream_vcs": "UPSTREAM_VCS"
+        }
+    ]}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "projects", "info", "--distro=test-distro", "bash")
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, infoCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"description\": \"The GNU Bourne Again shell")
+	assert.Contains(t, string(stdout), "\"version\": \"5.0.17\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/projects/info/bash?distro=test-distro\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -151,6 +352,7 @@ func TestCmdProjectsInfoBadDistro(t *testing.T) {
 	})
 
 	// Get the compose types
+	distro = ""
 	cmd, out, err := root.ExecuteTest("projects", "info", "--distro=homer", "bash")
 	defer out.Close()
 	require.NotNil(t, err)
@@ -164,5 +366,46 @@ func TestCmdProjectsInfoBadDistro(t *testing.T) {
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "DistroError: Invalid distro: homer")
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdProjectsInfoBadDistroJSON(t *testing.T) {
+	// Test the "projects info --distro=homer" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+        "errors": [
+            {
+                "id": "DistroError",
+                "msg": "Invalid distro: homer"
+            }
+        ],
+        "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get the compose types
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "projects", "info", "--distro=homer", "bash")
+	defer out.Close()
+	require.NotNil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, infoCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"DistroError\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"Invalid distro: homer\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/projects/info/bash?distro=homer\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
 }

--- a/cmd/composer-cli/projects/list.go
+++ b/cmd/composer-cli/projects/list.go
@@ -29,14 +29,11 @@ func init() {
 
 func list(cmd *cobra.Command, args []string) error {
 	projects, resp, err := root.Client.ListProjects(distro)
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "List Error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "List Error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	for _, p := range projects {

--- a/cmd/composer-cli/projects/list_test.go
+++ b/cmd/composer-cli/projects/list_test.go
@@ -80,6 +80,7 @@ func TestCmdProjectsList(t *testing.T) {
 		}, nil
 	})
 
+	distro = ""
 	cmd, out, err := root.ExecuteTest("projects", "list")
 	defer out.Close()
 	require.Nil(t, err)
@@ -92,6 +93,90 @@ func TestCmdProjectsList(t *testing.T) {
 	assert.Contains(t, string(stdout), "Name: 0ad\n")
 	assert.Contains(t, string(stdout), "Homepage: http://play0ad.com\n")
 	assert.Contains(t, string(stdout), "             open-source, cross-platform real-time")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/projects/list", mc.Req.URL.Path)
+}
+
+func TestCmdProjectsListJSON(t *testing.T) {
+	// Test the "projects list" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		var json string
+		if limit == 0 {
+			json = `{ "limit": 0, "offset": 0, "projects": [], "total": 1 }`
+		} else {
+			json = `{
+    "limit": 1,
+    "offset": 0,
+    "projects": [
+        {
+            "builds": [
+                {
+                    "arch": "x86_64",
+                    "build_config_ref": "BUILD_CONFIG_REF",
+                    "build_env_ref": "BUILD_ENV_REF",
+                    "build_time": "2020-07-31T23:48:35",
+                    "changelog": "CHANGELOG_NEEDED",
+                    "epoch": 0,
+                    "metadata": {},
+                    "release": "21.fc33",
+                    "source": {
+                        "license": "GPLv2+ and BSD and MIT and IBM",
+                        "metadata": {},
+                        "source_ref": "SOURCE_REF",
+                        "version": "0.0.23b"
+                    }
+                },
+                {
+                    "arch": "x86_64",
+                    "build_config_ref": "BUILD_CONFIG_REF",
+                    "build_env_ref": "BUILD_ENV_REF",
+                    "build_time": "2021-03-02T12:09:34",
+                    "changelog": "CHANGELOG_NEEDED",
+                    "epoch": 0,
+                    "metadata": {},
+                    "release": "2.fc33",
+                    "source": {
+                        "license": "GPLv2+ and BSD and MIT and IBM and MPLv2.0",
+                        "metadata": {},
+                        "source_ref": "SOURCE_REF",
+                        "version": "0.0.24b"
+                    }
+                }
+            ],
+            "description": "0 A.D. (pronounced \"zero ey-dee\") is a free, open-source, cross-platform\nreal-time strategy (RTS) game of ancient warfare. In short, it is a\nhistorically-based war/economy game that allows players to relive or rewrite\nthe history of Western civilizations, focusing on the years between 500 B.C.\nand 500 A.D. The project is highly ambitious, involving state-of-the-art 3D\ngraphics, detailed artwork, sound, and a flexible and powerful custom-built\ngame engine.\n\nThe game has been in development by Wildfire Games (WFG), a group of volunteer,\nhobbyist game developers, since 2001.",
+            "homepage": "http://play0ad.com",
+            "name": "0ad",
+"summary": "Cross-Platform RTS Game of Ancient Warfare",
+            "upstream_vcs": "UPSTREAM_VCS"
+        }],
+	"total": 1}`
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "projects", "list")
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"name\": \"0ad\"")
+	assert.Contains(t, string(stdout), "\"homepage\": \"http://play0ad.com\"")
+	assert.Contains(t, string(stdout), "\"version\": \"0.0.24b\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/projects/list?limit=0\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -162,6 +247,7 @@ func TestCmdProjectsListDistro(t *testing.T) {
 		}, nil
 	})
 
+	distro = ""
 	cmd, out, err := root.ExecuteTest("projects", "list", "--distro=test-distro")
 	defer out.Close()
 	require.Nil(t, err)
@@ -202,6 +288,7 @@ func TestCmdProjectsListBadDistro(t *testing.T) {
 	})
 
 	// Get the compose types
+	distro = ""
 	cmd, out, err := root.ExecuteTest("projects", "list", "--distro=homer")
 	defer out.Close()
 	require.NotNil(t, err)

--- a/cmd/composer-cli/root/printwrap_test.go
+++ b/cmd/composer-cli/root/printwrap_test.go
@@ -29,6 +29,7 @@ func capturePrintWrap(indent, columns int, s string) (*OutputCapture, error) {
 func TestPrintWrapSingle(t *testing.T) {
 	out, err := capturePrintWrap(4, 20, "Single line test")
 	require.Nil(t, err)
+	defer out.Close()
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
 	stdout, err := ioutil.ReadAll(out.Stdout)
@@ -42,6 +43,7 @@ func TestPrintWrapSingle(t *testing.T) {
 func TestPrintWrapMultiple(t *testing.T) {
 	out, err := capturePrintWrap(4, 20, "Multi-line test, with an indent on the second line printed")
 	require.Nil(t, err)
+	defer out.Close()
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
 	stdout, err := ioutil.ReadAll(out.Stdout)
@@ -55,6 +57,7 @@ func TestPrintWrapMultiple(t *testing.T) {
 func TestPrintWrapWithLF(t *testing.T) {
 	out, err := capturePrintWrap(4, 20, "Multi-line\n test, with an indent on the\n second line printed")
 	require.Nil(t, err)
+	defer out.Close()
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
 	stdout, err := ioutil.ReadAll(out.Stdout)

--- a/cmd/composer-cli/root/root.go
+++ b/cmd/composer-cli/root/root.go
@@ -105,7 +105,11 @@ func initConfig() {
 	}
 
 	Client = weldr.InitClientUnixSocket(ctx, apiVersion, socketPath)
+	setupJSONOutput()
+}
 
+// setupJSONOutput configures the callback function and disables Stdout
+func setupJSONOutput() {
 	if JSONOutput {
 		// Disable Stdout output so that only json is output
 		oldStdout = os.Stdout
@@ -130,7 +134,12 @@ func initConfig() {
 				}
 			}
 		})
-
+	} else {
+		if oldStdout != nil {
+			os.Stdout = oldStdout
+			oldStdout = nil
+		}
+		Client.SetRawCallback(func(string, string, int, []byte) {})
 	}
 }
 

--- a/cmd/composer-cli/root/root.go
+++ b/cmd/composer-cli/root/root.go
@@ -148,6 +148,14 @@ func ExecutionError(cmd *cobra.Command, format string, a ...interface{}) error {
 	return fmt.Errorf(s)
 }
 
+// ExecutionErrors prints a list of errors to stderr, then calls ExecutionError
+func ExecutionErrors(cmd *cobra.Command, errors []string) error {
+	for _, s := range errors {
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", s)
+	}
+	return ExecutionError(cmd, "")
+}
+
 // GetCommaArgs returns a list of the arguments, split by commas and spaces
 // They can be grouped or separated, the return list should be the same for all variations
 // empty fields, eg. ,, are ignored by collapsing repeated , and spaces into one.

--- a/cmd/composer-cli/root/test_utilities.go
+++ b/cmd/composer-cli/root/test_utilities.go
@@ -87,6 +87,11 @@ func (c *OutputCapture) Rewind() error {
 // is executed and subcommands dispatched in the same way they are during normal
 // operation.
 func ExecuteTest(args ...string) (*cobra.Command, *OutputCapture, error) {
+	// Reset the root flags
+	JSONOutput = false
+	testMode = 0
+	httpTimeout = 240
+
 	rootCmd.SetArgs(args)
 
 	output, err := NewOutputCapture()

--- a/cmd/composer-cli/sources/add.go
+++ b/cmd/composer-cli/sources/add.go
@@ -5,9 +5,7 @@
 package sources
 
 import (
-	"fmt"
 	"io/ioutil"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -37,7 +35,7 @@ func init() {
 	sourcesCmd.AddCommand(changeCmd)
 }
 
-func add(cmd *cobra.Command, args []string) (rcErr error) {
+func add(cmd *cobra.Command, args []string) error {
 	data, err := ioutil.ReadFile(args[0])
 	if err != nil {
 		return root.ExecutionError(cmd, "Missing source file: %s\n", args[0])
@@ -46,15 +44,9 @@ func add(cmd *cobra.Command, args []string) (rcErr error) {
 	if err != nil {
 		return root.ExecutionError(cmd, "Add source TOML: %s\n", err)
 	}
-	if root.JSONOutput {
-		return nil
-	}
 	if resp != nil && !resp.Status {
-		for _, e := range resp.AllErrors() {
-			fmt.Fprintf(os.Stderr, "ERROR: %s\n", e)
-		}
-		rcErr = root.ExecutionError(cmd, "")
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
-	return rcErr
+	return nil
 }

--- a/cmd/composer-cli/sources/add_test.go
+++ b/cmd/composer-cli/sources/add_test.go
@@ -42,6 +42,7 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	require.Nil(t, err)
 
 	cmd, out, err := root.ExecuteTest("sources", "add", tmpSrc.Name())
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -56,6 +57,62 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
 	assert.Equal(t, "/api/v1/projects/source/new", mc.Req.URL.Path)
+	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	mc.Req.Body.Close()
+	require.Nil(t, err)
+	assert.Contains(t, string(sentBody), "check_ssl = true")
+	assert.Contains(t, string(sentBody), "id = \"test-source-1\"")
+	assert.Equal(t, "text/x-toml", mc.Req.Header.Get("Content-Type"))
+}
+
+func TestCmdSourcesAddJSON(t *testing.T) {
+	// Test the "sources add" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{"status": true}`
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Need a temporary test file
+	tmpSrc, err := ioutil.TempFile("", "test-src-*.toml")
+	require.Nil(t, err)
+	defer os.Remove(tmpSrc.Name())
+
+	_, err = tmpSrc.Write([]byte(`check_gpg = true
+check_ssl = true
+id = "test-source-1"
+name = "Test source"
+type = "yum-metalink"
+url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
+`))
+	require.Nil(t, err)
+
+	cmd, out, err := root.ExecuteTest("--json", "sources", "add", tmpSrc.Name())
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, addCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": true")
+	assert.Contains(t, string(stdout), "\"path\": \"/projects/source/new\"")
+	assert.Contains(t, string(stdout), "\"method\": \"POST\"")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "POST", mc.Req.Method)
+	assert.Equal(t, "/api/v1/projects/source/new", mc.Req.URL.Path)
+	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	mc.Req.Body.Close()
+	require.Nil(t, err)
+	assert.Contains(t, string(sentBody), "check_ssl = true")
+	assert.Contains(t, string(sentBody), "id = \"test-source-1\"")
+	assert.Equal(t, "text/x-toml", mc.Req.Header.Get("Content-Type"))
 }
 
 func TestCmdNewSourceAddError(t *testing.T) {
@@ -93,6 +150,7 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	require.Nil(t, err)
 
 	cmd, out, err := root.ExecuteTest("sources", "add", tmpSrc.Name())
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
 
@@ -106,6 +164,61 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "ProjectsError")
+	assert.Equal(t, "POST", mc.Req.Method)
+	assert.Equal(t, "/api/v1/projects/source/new", mc.Req.URL.Path)
+}
+
+func TestCmdNewSourceAddErrorJSON(t *testing.T) {
+	// Test the "sources add" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "errors": [
+        {
+            "id": "ProjectsError",
+            "msg": "Problem parsing POST body: Near line 4 (last key parsed 'name'): strings cannot contain newlines"
+        }
+    ],
+    "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Need a temporary test file
+	tmpSrc, err := ioutil.TempFile("", "test-src-*.toml")
+	require.Nil(t, err)
+	defer os.Remove(tmpSrc.Name())
+
+	_, err = tmpSrc.Write([]byte(`check_gpg = true
+check_ssl = true
+id = "test-source-1"
+name = "Test source
+type = "yum-metalink"
+url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
+`))
+	require.Nil(t, err)
+
+	cmd, out, err := root.ExecuteTest("--json", "sources", "add", tmpSrc.Name())
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, addCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"ProjectsError\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"Problem parsing POST body")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
 	assert.Equal(t, "/api/v1/projects/source/new", mc.Req.URL.Path)
 }
@@ -135,6 +248,7 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	require.Nil(t, err)
 
 	cmd, out, err := root.ExecuteTest("sources", "change", tmpSrc.Name())
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -144,6 +258,50 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "POST", mc.Req.Method)
+	assert.Equal(t, "/api/v1/projects/source/new", mc.Req.URL.Path)
+}
+
+func TestCmdSourcesChangeJSON(t *testing.T) {
+	// Test the "sources change" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{"status": true}`
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Need a temporary test file
+	tmpSrc, err := ioutil.TempFile("", "test-src-*.toml")
+	require.Nil(t, err)
+	defer os.Remove(tmpSrc.Name())
+
+	_, err = tmpSrc.Write([]byte(`check_gpg = true
+check_ssl = true
+id = "test-source-1"
+name = "Test source"
+type = "yum-metalink"
+url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
+`))
+	require.Nil(t, err)
+
+	cmd, out, err := root.ExecuteTest("--json", "sources", "change", tmpSrc.Name())
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, changeCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": true")
+	assert.Contains(t, string(stdout), "\"path\": \"/projects/source/new\"")
+	assert.Contains(t, string(stdout), "\"method\": \"POST\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -186,6 +344,7 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	require.Nil(t, err)
 
 	cmd, out, err := root.ExecuteTest("sources", "change", tmpSrc.Name())
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
 
@@ -199,6 +358,61 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "ProjectsError")
+	assert.Equal(t, "POST", mc.Req.Method)
+	assert.Equal(t, "/api/v1/projects/source/new", mc.Req.URL.Path)
+}
+
+func TestCmdNewSourceChangeErrorJSON(t *testing.T) {
+	// Test the "sources change" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "errors": [
+        {
+            "id": "ProjectsError",
+            "msg": "Problem parsing POST body: Near line 4 (last key parsed 'name'): strings cannot contain newlines"
+        }
+    ],
+    "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Need a temporary test file
+	tmpSrc, err := ioutil.TempFile("", "test-src-*.toml")
+	require.Nil(t, err)
+	defer os.Remove(tmpSrc.Name())
+
+	_, err = tmpSrc.Write([]byte(`check_gpg = true
+check_ssl = true
+id = "test-source-1"
+name = "Test source
+type = "yum-metalink"
+url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
+`))
+	require.Nil(t, err)
+
+	cmd, out, err := root.ExecuteTest("--json", "sources", "change", tmpSrc.Name())
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, changeCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"ProjectsError\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"Problem parsing POST body")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
 	assert.Equal(t, "/api/v1/projects/source/new", mc.Req.URL.Path)
 }

--- a/cmd/composer-cli/sources/delete.go
+++ b/cmd/composer-cli/sources/delete.go
@@ -29,11 +29,8 @@ func delete(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return root.ExecutionError(cmd, "Delete Error: %s", err)
 	}
-	if root.JSONOutput {
-		return nil
-	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "Delete Error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	return nil

--- a/cmd/composer-cli/sources/delete_test.go
+++ b/cmd/composer-cli/sources/delete_test.go
@@ -28,6 +28,7 @@ func TestCmdSourcesDelete(t *testing.T) {
 	})
 
 	cmd, out, err := root.ExecuteTest("sources", "delete", "test-source-1")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -37,6 +38,35 @@ func TestCmdSourcesDelete(t *testing.T) {
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "DELETE", mc.Req.Method)
+	assert.Equal(t, "/api/v1/projects/source/delete/test-source-1", mc.Req.URL.Path)
+}
+
+func TestCmdSourcesDeleteJSON(t *testing.T) {
+	// Test the "sources delete" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{"status": true}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "sources", "delete", "test-source-1")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, deleteCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": true")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
@@ -67,6 +97,7 @@ func TestCmdSourcesDeleteSystem(t *testing.T) {
 	})
 
 	cmd, out, err := root.ExecuteTest("sources", "delete", "fedora")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.NotNil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -79,6 +110,47 @@ func TestCmdSourcesDeleteSystem(t *testing.T) {
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "SystemSource")
+	assert.Equal(t, "DELETE", mc.Req.Method)
+	assert.Equal(t, "/api/v1/projects/source/delete/fedora", mc.Req.URL.Path)
+}
+
+func TestCmdSourcesDeleteSystemJSON(t *testing.T) {
+	// Test the "sources delete" command with a system source
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+    "errors": [
+        {
+            "id": "SystemSource",
+            "msg": "fedora is a system source, it cannot be deleted."
+        }
+    ],
+    "status": false
+}`
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "sources", "delete", "fedora")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, deleteCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"SystemSource\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"fedora is a system source, it cannot be deleted.\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/projects/source/delete/fedora\"")
+	assert.Contains(t, string(stdout), "\"status\": 400")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
 	assert.Equal(t, "/api/v1/projects/source/delete/fedora", mc.Req.URL.Path)
 }

--- a/cmd/composer-cli/sources/info_test.go
+++ b/cmd/composer-cli/sources/info_test.go
@@ -6,6 +6,7 @@ package sources
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -46,7 +47,8 @@ func TestCmdSourcesInfo(t *testing.T) {
 
 	cmd, out, err := root.ExecuteTest("sources", "info", "fedora,unknown")
 	defer out.Close()
-	require.Nil(t, err)
+	require.NotNil(t, err)
+	assert.Equal(t, err, fmt.Errorf(""))
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)

--- a/cmd/composer-cli/sources/list.go
+++ b/cmd/composer-cli/sources/list.go
@@ -28,14 +28,11 @@ func init() {
 
 func list(cmd *cobra.Command, args []string) error {
 	sources, resp, err := root.Client.ListSources()
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "Types Error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "Types Error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	for _, name := range sources {

--- a/cmd/composer-cli/sources/list_test.go
+++ b/cmd/composer-cli/sources/list_test.go
@@ -29,6 +29,7 @@ func TestCmdSourcesList(t *testing.T) {
 
 	// Get the list of sources
 	cmd, out, err := root.ExecuteTest("sources", "list")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -38,6 +39,37 @@ func TestCmdSourcesList(t *testing.T) {
 	stdout, err := ioutil.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotEqual(t, []byte(""), stdout)
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdSourcesListJSON(t *testing.T) {
+	// Test the "sources list" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{"sources":["fedora","updates","fedora-modular","updates-modular"]}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get the list of sources
+	cmd, out, err := root.ExecuteTest("--json", "sources", "list")
+	defer out.Close()
+	require.NotNil(t, out)
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"sources\"")
+	assert.Contains(t, string(stdout), "\"fedora\"")
+	assert.Contains(t, string(stdout), "\"updates\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)

--- a/cmd/composer-cli/status/show.go
+++ b/cmd/composer-cli/status/show.go
@@ -27,14 +27,11 @@ func init() {
 
 func show(cmd *cobra.Command, args []string) error {
 	status, resp, err := root.Client.ServerStatus()
-	if root.JSONOutput {
-		return nil
-	}
 	if err != nil {
 		return root.ExecutionError(cmd, "Show Error: %s", err)
 	}
 	if resp != nil && !resp.Status {
-		return root.ExecutionError(cmd, "Show Error: %s", resp.String())
+		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
 	fmt.Println("API server status:")

--- a/cmd/composer-cli/status/show_test.go
+++ b/cmd/composer-cli/status/show_test.go
@@ -28,6 +28,7 @@ func TestCmdStatusShow(t *testing.T) {
 	})
 
 	cmd, out, err := root.ExecuteTest("status", "show")
+	require.NotNil(t, out)
 	defer out.Close()
 	require.Nil(t, err)
 	require.NotNil(t, out.Stdout)
@@ -39,6 +40,37 @@ func TestCmdStatusShow(t *testing.T) {
 	assert.Contains(t, string(stdout), "API server status:")
 	assert.Contains(t, string(stdout), "Backend:            osbuild-composer")
 	assert.Contains(t, string(stdout), "Build:              devel")
+	stderr, err := ioutil.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/status", mc.Req.URL.Path)
+}
+
+func TestCmdStatusShowJSON(t *testing.T) {
+	// Test the "status show" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{"api":"1","db_supported":true,"db_version":"0","schema_version":"0","backend":"osbuild-composer","build":"devel","msgs":[]}`
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	cmd, out, err := root.ExecuteTest("--json", "status", "show")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, showCmd)
+	stdout, err := ioutil.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "\"api\": \"1\"")
+	assert.Contains(t, string(stdout), "\"backend\": \"osbuild-composer\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/api/status\"")
 	stderr, err := ioutil.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)

--- a/weldr/apischema.go
+++ b/weldr/apischema.go
@@ -18,7 +18,7 @@ type APIErrorMsg struct {
 }
 
 // String returns the error id and message as a string
-func (r *APIErrorMsg) String() string {
+func (r APIErrorMsg) String() string {
 	return fmt.Sprintf("%s: %s", r.ID, r.Msg)
 }
 
@@ -32,7 +32,7 @@ type APIResponse struct {
 }
 
 // String returns the description of the first error, if there is one
-func (r *APIResponse) String() string {
+func (r APIResponse) String() string {
 	if len(r.Errors) == 0 {
 		return ""
 	}

--- a/weldr/blueprints.go
+++ b/weldr/blueprints.go
@@ -83,10 +83,7 @@ func (c Client) GetBlueprintsJSON(names []string) ([]interface{}, []APIErrorMsg,
 	}
 	err = json.Unmarshal(j, &r)
 	if err != nil {
-		errors = append(errors, APIErrorMsg{"JSONError", err.Error()})
-	}
-	if len(errors) > 0 {
-		return nil, errors, nil
+		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
 	if len(r.Errors) > 0 {
 		errors = append(errors, r.Errors...)
@@ -115,10 +112,7 @@ func (c Client) GetFrozenBlueprintsJSON(names []string) (blueprints []interface{
 	}
 	err = json.Unmarshal(j, &r)
 	if err != nil {
-		errors = append(errors, APIErrorMsg{"JSONError", err.Error()})
-	}
-	if len(errors) > 0 {
-		return nil, errors, nil
+		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
 	if len(r.Errors) > 0 {
 		errors = append(errors, r.Errors...)
@@ -220,10 +214,7 @@ func (c Client) GetBlueprintsChanges(names []string) ([]BlueprintChanges, []APIE
 	var changes BlueprintsChangesV0
 	err = json.Unmarshal(j, &changes)
 	if err != nil {
-		errors = append(errors, APIErrorMsg{"JSONError", err.Error()})
-	}
-	if len(errors) > 0 {
-		return nil, errors, nil
+		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
 	if len(changes.Errors) > 0 {
 		errors = append(errors, changes.Errors...)
@@ -252,10 +243,7 @@ func (c Client) DepsolveBlueprints(names []string) (blueprints []interface{}, er
 	}
 	err = json.Unmarshal(j, &r)
 	if err != nil {
-		errors = append(errors, APIErrorMsg{"JSONError", err.Error()})
-	}
-	if len(errors) > 0 {
-		return nil, errors, nil
+		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
 	if len(r.Errors) > 0 {
 		errors = append(errors, r.Errors...)

--- a/weldr/compose.go
+++ b/weldr/compose.go
@@ -33,11 +33,10 @@ func (c Client) ListComposes() ([]ComposeStatusV0, []APIErrorMsg, error) {
 	}
 	err = json.Unmarshal(j, &queue)
 	if err != nil {
-		errors = append(errors, APIErrorMsg{"JSONError", err.Error()})
-	} else {
-		composes = append(composes, queue.New...)
-		composes = append(composes, queue.Run...)
+		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
+	composes = append(composes, queue.New...)
+	composes = append(composes, queue.Run...)
 
 	j, resp, err = c.GetRaw("GET", "/compose/finished")
 	if err != nil {
@@ -54,10 +53,9 @@ func (c Client) ListComposes() ([]ComposeStatusV0, []APIErrorMsg, error) {
 	}
 	err = json.Unmarshal(j, &finished)
 	if err != nil {
-		errors = append(errors, APIErrorMsg{"JSONError", err.Error()})
-	} else {
-		composes = append(composes, finished.Finished...)
+		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
+	composes = append(composes, finished.Finished...)
 
 	j, resp, err = c.GetRaw("GET", "/compose/failed")
 	if err != nil {
@@ -74,10 +72,9 @@ func (c Client) ListComposes() ([]ComposeStatusV0, []APIErrorMsg, error) {
 	}
 	err = json.Unmarshal(j, &failed)
 	if err != nil {
-		errors = append(errors, APIErrorMsg{"JSONError", err.Error()})
-	} else {
-		composes = append(composes, failed.Failed...)
+		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
+	composes = append(composes, failed.Failed...)
 	if len(errors) > 0 {
 		return nil, errors, nil
 	}
@@ -304,10 +301,7 @@ func (c Client) DeleteComposes(ids []string) ([]ComposeDeleteV0, []APIErrorMsg, 
 	}
 	err = json.Unmarshal(j, &r)
 	if err != nil {
-		errors = append(errors, APIErrorMsg{"JSONError", err.Error()})
-	}
-	if len(errors) > 0 {
-		return nil, errors, nil
+		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
 	if len(r.Errors) > 0 {
 		errors = append(errors, r.Errors...)
@@ -332,9 +326,9 @@ func (c Client) CancelCompose(id string) (ComposeCancelV0, []APIErrorMsg, error)
 	// cancel returns the status of the single build id it was asked to cancel
 	err = json.Unmarshal(j, &r)
 	if err != nil {
-		errors = append(errors, APIErrorMsg{"JSONError", err.Error()})
+		return r, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
-	return r, errors, nil
+	return r, nil, nil
 }
 
 // ComposeLog returns the last 1k of logs from a running compose
@@ -396,7 +390,7 @@ func (c Client) ComposeInfo(id string) (info ComposeInfoV0, resp *APIResponse, e
 
 	err = json.Unmarshal(j, &info)
 	if err != nil {
-		resp = &APIResponse{false, []APIErrorMsg{{"JSONError", err.Error()}}}
+		return info, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
 	return info, resp, nil
 }

--- a/weldr/modules.go
+++ b/weldr/modules.go
@@ -53,7 +53,7 @@ func (c Client) ModulesInfo(names []string, distro string) ([]ProjectV0, *APIRes
 	}
 	err = json.Unmarshal(j, &r)
 	if err != nil {
-		resp = &APIResponse{Status: false, Errors: []APIErrorMsg{{"JSONError", err.Error()}}}
+		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
 	return r.Modules, resp, nil
 }

--- a/weldr/projects.go
+++ b/weldr/projects.go
@@ -51,7 +51,7 @@ func (c Client) ProjectsInfo(projs []string, distro string) ([]ProjectV0, *APIRe
 	}
 	err = json.Unmarshal(j, &r)
 	if err != nil {
-		resp = &APIResponse{Status: false, Errors: []APIErrorMsg{{"JSONError", err.Error()}}}
+		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
 	return r.Projects, resp, nil
 }
@@ -81,10 +81,7 @@ func (c Client) DepsolveProjects(names []string, distro string) (deps []interfac
 	}
 	err = json.Unmarshal(j, &r)
 	if err != nil {
-		errors = append(errors, APIErrorMsg{"JSONError", err.Error()})
-	}
-	if len(errors) > 0 {
-		return nil, errors, nil
+		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
 	if len(r.Errors) > 0 {
 		errors = append(errors, r.Errors...)

--- a/weldr/projects.go
+++ b/weldr/projects.go
@@ -70,8 +70,7 @@ func (c Client) DepsolveProjects(names []string, distro string) (deps []interfac
 		return nil, nil, err
 	}
 	if resp != nil {
-		errors = append(errors, resp.Errors...)
-		return nil, errors, nil
+		return nil, resp.Errors, nil
 	}
 
 	// flexible response unmarshaling, be strict about the error message
@@ -84,8 +83,7 @@ func (c Client) DepsolveProjects(names []string, distro string) (deps []interfac
 		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
 	if len(r.Errors) > 0 {
-		errors = append(errors, r.Errors...)
+		return r.Projects, r.Errors, nil
 	}
-
-	return r.Projects, errors, nil
+	return r.Projects, nil, nil
 }

--- a/weldr/sources.go
+++ b/weldr/sources.go
@@ -36,15 +36,13 @@ func (c Client) ListSources() ([]string, *APIResponse, error) {
 // It uses interface{} for the sources so that it is not tightly coupled to the server's source
 // schema.
 func (c Client) GetSourcesJSON(names []string) (map[string]interface{}, []APIErrorMsg, error) {
-	var errors []APIErrorMsg
 	route := fmt.Sprintf("/projects/source/info/%s", strings.Join(names, ","))
 	j, resp, err := c.GetRaw("GET", route)
 	if err != nil {
 		return nil, nil, err
 	}
 	if resp != nil {
-		errors = append(errors, resp.Errors...)
-		return nil, errors, nil
+		return nil, resp.Errors, nil
 	}
 
 	// flexible source unmarshaling, be strict about the error message
@@ -57,9 +55,9 @@ func (c Client) GetSourcesJSON(names []string) (map[string]interface{}, []APIErr
 		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
 	if len(r.Errors) > 0 {
-		errors = append(errors, r.Errors...)
+		return r.Sources, r.Errors, nil
 	}
-	return r.Sources, errors, nil
+	return r.Sources, nil, nil
 }
 
 // NewSourceTOML adds (or updates if it already exists) a source using TOML

--- a/weldr/sources.go
+++ b/weldr/sources.go
@@ -54,10 +54,7 @@ func (c Client) GetSourcesJSON(names []string) (map[string]interface{}, []APIErr
 	}
 	err = json.Unmarshal(j, &r)
 	if err != nil {
-		errors = append(errors, APIErrorMsg{"JSONError", err.Error()})
-	}
-	if len(errors) > 0 {
-		return nil, errors, nil
+		return nil, nil, fmt.Errorf("ERROR: %s", err.Error())
 	}
 	if len(r.Errors) > 0 {
 		errors = append(errors, r.Errors...)


### PR DESCRIPTION
Fixes #21

This re-works how json and non-json output is handled. Now the normal command logic always runs and the return code is the same. Also added a pile of tests for --json mode which weren't really possible before.
