### PR TITLE
spec: Add build flags to composer-cli-test build cmdline

### DIFF
--- a/weldr-client.spec.in
+++ b/weldr-client.spec.in
@@ -83,8 +83,8 @@ export BUILDTAGS="integration"
 # On Fedora, also turn off go modules and set the path to the one into which
 # the golang-* packages install source code.
 %if 0%{?rhel}
-export LDFLAGS="${LDFLAGS:-} -B 0x$(od -N 20 -An -tx1 -w100 /dev/urandom | tr -d ' ')"
-go test -c -tags=integration -ldflags="${LDFLAGS}" -o composer-cli-tests %{goipath}/weldr
+export LDFLAGS="${LDFLAGS:-} -linkmode=external -compressdwarf=false -B 0x$(od -N 20 -An -tx1 -w100 /dev/urandom | tr -d ' ')"
+go test -c -tags=integration -buildmode pie -compiler gc -ldflags="${LDFLAGS}" -o composer-cli-tests %{goipath}/weldr
 %else
 make GOBUILDFLAGS="%{gobuildflags}" integration
 %endif


### PR DESCRIPTION
The go macros for building tests doesn't support custom tags or building
a test binary so we have to specify the options manually. annocheck
complains if the buildmode isn't set to pie, so copy in more of the
build macro settings.