### PR TITLE
composer-cli: Return a helpful error for socket problems

### DIFF
--- a/cmd/composer-cli/root/root.go
+++ b/cmd/composer-cli/root/root.go
@@ -145,6 +145,10 @@ func setupJSONOutput() {
 
 // Execute runs the commands on the commandline
 func Execute() error {
+	if ok, err := weldr.CheckSocket(socketPath); !ok {
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+		return err
+	}
 	return rootCmd.Execute()
 }
 

--- a/weldr/common_test.go
+++ b/weldr/common_test.go
@@ -15,6 +15,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCheckSocket(t *testing.T) {
+
+	// Test with missing file
+	ok, err := CheckSocket("/run/missing/file.socket")
+	assert.False(t, ok)
+	assert.NotNil(t, err)
+	assert.Contains(t, fmt.Sprintf("%s", err), "Check to make sure that")
+
+	// Test with existing file
+	f, err := ioutil.TempFile("", "test-CheckSocket-*")
+	require.Nil(t, err)
+	_, err = f.Write([]byte("This is just a test file\n"))
+	require.Nil(t, err)
+	f.Close()
+
+	ok, err = CheckSocket(f.Name())
+	assert.True(t, ok)
+	assert.Nil(t, err)
+
+	// NOTE: Cannot test permissons. root has access, and user cannot change them
+	// to something it isn't allowed to access.
+}
+
 func TestRequestMethods(t *testing.T) {
 	// Test the GET, POST, DELETE methods
 	mc := MockClient{

--- a/weldr/integration_test.go
+++ b/weldr/integration_test.go
@@ -153,7 +153,7 @@ func executeTests(m *testing.M) int {
 			panic(err)
 		}
 		if resp != nil {
-			panic(errors.New("StartComposeTest failed"))
+			panic(fmt.Errorf("StartComposeTest 1 failed: %#v", resp))
 		}
 	}
 
@@ -164,7 +164,7 @@ func executeTests(m *testing.M) int {
 			panic(err)
 		}
 		if resp != nil {
-			panic(errors.New("StartComposeTest failed"))
+			panic(fmt.Errorf("StartComposeTest 2 failed: %#v", resp))
 		}
 	}
 


### PR DESCRIPTION
Tell the user to start osbuild-composer if the socket file is missing,
and tell them to check the socket's group (usually weldr, but it pulls
it from the socket file itself) if the file exists but cannot be
accessed.

Includes test for present and missing socket file.
We cannot test for permissions because as root it always has access, and
as a user it cannot make a file that it doesn't already have access to.