### PR TITLE
tests: trigger on push to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
       - "*"
   push:
     branches:
-      - master
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
master branch doesn't exist anymore so I think it makes sense to change it to `main` which will hopefully also trigger the gitlab CI for main branch when a PR is merged.