### PR TITLE
Replace deprecated ioutil functions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
         go:
           - 16
           - 17
+          - 18
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -37,6 +38,7 @@ jobs:
         go:
           - 16
           - 17
+          - 18
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -48,8 +50,8 @@ jobs:
       - name: Run unit tests on go 1.${{matrix.go}}.x
         run: make test
 
-      - name: Send coverage to codecov.io for go v1.17.x
-        if: matrix.go == 17
+      - name: Send coverage to codecov.io for go v1.18.x
+        if: matrix.go == 18
         run: bash <(curl -s https://codecov.io/bash)
 
   build-test:

--- a/cmd/composer-cli/blueprints/changes_test.go
+++ b/cmd/composer-cli/blueprints/changes_test.go
@@ -7,7 +7,7 @@ package blueprints
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -43,7 +43,7 @@ func TestCmdBlueprintsChanges(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(jsonResponse))),
 		}, nil
 	})
 
@@ -55,12 +55,12 @@ func TestCmdBlueprintsChanges(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, changesCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "cli-test-bp-1")
 	assert.Contains(t, string(stdout), "reverted to commit f48b415828fa7179acd17b1f1b69e11c2c3fcd17")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, "", string(stderr))
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -93,7 +93,7 @@ func TestCmdBlueprintsChangesJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(jsonResponse))),
 		}, nil
 	})
 
@@ -105,13 +105,13 @@ func TestCmdBlueprintsChangesJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, changesCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
 	assert.Contains(t, string(stdout), "\"message\": \"cli-test-bp-1.toml reverted to commit f48b415828fa7179acd17b1f1b69e11c2c3fcd17\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/changes/cli-test-bp-1?limit=0\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, "", string(stderr))
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -143,7 +143,7 @@ func TestCmdBlueprintsChangesUnknown(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(jsonResponse))),
 		}, nil
 	})
 
@@ -155,12 +155,12 @@ func TestCmdBlueprintsChangesUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, changesCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "cli-test-bp-1")
 	assert.Contains(t, string(stdout), "reverted to commit f48b415828fa7179acd17b1f1b69e11c2c3fcd17")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "ERROR: UnknownBlueprint: no-bp-test")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -192,7 +192,7 @@ func TestCmdBlueprintsChangesJSONUnknown(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(jsonResponse))),
 		}, nil
 	})
 
@@ -205,7 +205,7 @@ func TestCmdBlueprintsChangesJSONUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, changesCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
@@ -213,7 +213,7 @@ func TestCmdBlueprintsChangesJSONUnknown(t *testing.T) {
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/changes/cli-test-bp-1,test-no-bp?limit=0\"")
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownBlueprint\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"no-bp-test\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, "", string(stderr))
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/blueprints/delete_test.go
+++ b/cmd/composer-cli/blueprints/delete_test.go
@@ -6,7 +6,7 @@ package blueprints
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -23,7 +23,7 @@ func TestCmdBlueprintsDelete(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -35,10 +35,10 @@ func TestCmdBlueprintsDelete(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, deleteCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
@@ -52,7 +52,7 @@ func TestCmdBlueprintsDeleteJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -64,12 +64,12 @@ func TestCmdBlueprintsDeleteJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, deleteCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": true")
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/delete/cli-test-bp-1\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
@@ -88,7 +88,7 @@ func TestCmdBlueprintsDeleteUnknown(t *testing.T) {
 }`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -100,10 +100,10 @@ func TestCmdBlueprintsDeleteUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, deleteCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
@@ -122,7 +122,7 @@ func TestCmdBlueprintsDeleteJSONUnknown(t *testing.T) {
 }`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -134,13 +134,13 @@ func TestCmdBlueprintsDeleteJSONUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, deleteCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"id\": \"BlueprintsError\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"Unknown blueprint: foo-bp-1\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/delete/foo-bp-1\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)

--- a/cmd/composer-cli/blueprints/depsolve_test.go
+++ b/cmd/composer-cli/blueprints/depsolve_test.go
@@ -6,7 +6,7 @@ package blueprints
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -64,7 +64,7 @@ func TestCmdBlueprintsDepsolve(t *testing.T) {
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -77,12 +77,12 @@ func TestCmdBlueprintsDepsolve(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, depsolveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "cli-test-bp-1")
 	assert.Contains(t, string(stdout), "acl-2.2.53-9.fc33.x86_64")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "UnknownBlueprint: test-no-bp: blueprint not found")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -137,7 +137,7 @@ func TestCmdBlueprintsDepsolveJSON(t *testing.T) {
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -150,7 +150,7 @@ func TestCmdBlueprintsDepsolveJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, depsolveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
@@ -158,7 +158,7 @@ func TestCmdBlueprintsDepsolveJSON(t *testing.T) {
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/depsolve/cli-test-bp-1,test-no-bp\"")
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownBlueprint\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"test-no-bp: blueprint not found\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -195,7 +195,7 @@ func TestCmdBlueprintsBadDepsolve(t *testing.T) {
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -208,11 +208,11 @@ func TestCmdBlueprintsBadDepsolve(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, depsolveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "blueprint: cli-test-bp-1 v0.0.1")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "BlueprintsError: cli-test-bp-1: DNF error occured:")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -249,7 +249,7 @@ func TestCmdBlueprintsBadDepsolveJSON(t *testing.T) {
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -261,14 +261,14 @@ func TestCmdBlueprintsBadDepsolveJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, depsolveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
 	assert.Contains(t, string(stdout), "\"id\": \"BlueprintsError\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"cli-test-bp-1: DNF error occured:")
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/depsolve/cli-test-bp-1\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, "", string(stderr))
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/blueprints/freeze_test.go
+++ b/cmd/composer-cli/blueprints/freeze_test.go
@@ -6,7 +6,7 @@ package blueprints
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -60,7 +60,7 @@ func TestCmdBlueprintsFreeze(t *testing.T) {
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -79,13 +79,13 @@ func TestCmdBlueprintsFreeze(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, freezeCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "blueprint: cli-test-bp-1 v0.0.3")
 	assert.Contains(t, string(stdout), "tmux-3.1c-2.fc34.x86_64")
 	assert.NotContains(t, string(stdout), "1001.0")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "UnknownBlueprint: test-no-bp: blueprint not found")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -135,7 +135,7 @@ func TestCmdBlueprintsFreezeJSON(t *testing.T) {
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -154,7 +154,7 @@ func TestCmdBlueprintsFreezeJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, freezeCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
@@ -162,7 +162,7 @@ func TestCmdBlueprintsFreezeJSON(t *testing.T) {
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownBlueprint\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"test-no-bp: blueprint not found\"")
 	assert.NotContains(t, string(stdout), "1001.0")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, "", string(stderr))
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -190,11 +190,11 @@ uid = 1001
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(toml))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(toml))),
 		}, nil
 	})
 
-	dir, err := ioutil.TempDir("", "test-bp-save-*")
+	dir, err := os.MkdirTemp("", "test-bp-save-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -215,10 +215,10 @@ uid = 1001
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, freezeSaveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -253,11 +253,11 @@ uid = 1001
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(toml))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(toml))),
 		}, nil
 	})
 
-	dir, err := ioutil.TempDir("", "test-bp-save-*")
+	dir, err := os.MkdirTemp("", "test-bp-save-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -278,10 +278,10 @@ uid = 1001
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, freezeSaveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -353,11 +353,11 @@ uid = 1001
 		}
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(data))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(data))),
 		}, nil
 	})
 
-	dir, err := ioutil.TempDir("", "test-bp-save-*")
+	dir, err := os.MkdirTemp("", "test-bp-save-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -378,13 +378,13 @@ uid = 1001
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, freezeSaveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
 	assert.Contains(t, string(stdout), "\"version\": \"3.1c-2.fc34.x86_64\"")
 	assert.NotContains(t, string(stdout), "1001.0")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -420,7 +420,7 @@ uid = 1001
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(toml))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(toml))),
 		}, nil
 	})
 
@@ -434,14 +434,14 @@ uid = 1001
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, freezeShowCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "name = \"cli-test-bp-1\"")
 	assert.Contains(t, string(stdout), "[[packages]]")
 	assert.Contains(t, string(stdout), "version = \"3.1c-2.fc34.x86_64\"")
 	assert.NotContains(t, string(stdout), "1001.0")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, "", string(stderr))
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -488,7 +488,7 @@ func TestCmdBlueprintsFreezeShowJSON(t *testing.T) {
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -503,14 +503,14 @@ func TestCmdBlueprintsFreezeShowJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, freezeShowCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"cli-test-bp-1\"")
 	assert.Contains(t, string(stdout), "\"version\": \"3.1c-2.fc34.x86_64\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/freeze/cli-test-bp-1\"")
 	assert.NotContains(t, string(stdout), "1001.0")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, "", string(stderr))
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/blueprints/list_test.go
+++ b/cmd/composer-cli/blueprints/list_test.go
@@ -6,7 +6,7 @@ package blueprints
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -32,7 +32,7 @@ func TestCmdBlueprintsList(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -44,12 +44,12 @@ func TestCmdBlueprintsList(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "http-server-prod")
 	assert.Contains(t, string(stdout), "nfs-server-test")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -71,7 +71,7 @@ func TestCmdBlueprintsListJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -83,14 +83,14 @@ func TestCmdBlueprintsListJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"blueprints\": [\n")
 	assert.Contains(t, string(stdout), "\"http-server-prod\",")
 	assert.Contains(t, string(stdout), "\"total\": 2")
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/list?limit=2\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/blueprints/push.go
+++ b/cmd/composer-cli/blueprints/push.go
@@ -6,7 +6,6 @@ package blueprints
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -31,7 +30,7 @@ func init() {
 func push(cmd *cobra.Command, args []string) (rcErr error) {
 	files := root.GetCommaArgs(args)
 	for _, filename := range files {
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		if err != nil {
 			rcErr = root.ExecutionError(cmd, "Missing blueprint file: %s\n", filename)
 			continue

--- a/cmd/composer-cli/blueprints/push_test.go
+++ b/cmd/composer-cli/blueprints/push_test.go
@@ -6,7 +6,7 @@ package blueprints
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -23,12 +23,12 @@ func TestCmdBlueprintsPush(t *testing.T) {
 		json := `{"status": true}`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpBp, err := ioutil.TempFile("", "test-bp-*.toml")
+	tmpBp, err := os.CreateTemp("", "test-bp-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpBp.Name())
 
@@ -48,10 +48,10 @@ version = "*"`))
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, pushCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -64,12 +64,12 @@ func TestCmdBlueprintsPushJSON(t *testing.T) {
 		json := `{"status": true}`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpBp, err := ioutil.TempFile("", "test-bp-*.toml")
+	tmpBp, err := os.CreateTemp("", "test-bp-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpBp.Name())
 
@@ -89,13 +89,13 @@ version = "*"`))
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, pushCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": true")
 	assert.Contains(t, string(stdout), "\"method\": \"POST\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/new\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -118,12 +118,12 @@ func TestCmdBlueprintsPushError(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpBp, err := ioutil.TempFile("", "test-bp-*.toml")
+	tmpBp, err := os.CreateTemp("", "test-bp-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpBp.Name())
 
@@ -143,10 +143,10 @@ version = "*"`))
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, pushCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "BlueprintsError")
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -169,12 +169,12 @@ func TestCmdBlueprintsPushErrorJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpBp, err := ioutil.TempFile("", "test-bp-*.toml")
+	tmpBp, err := os.CreateTemp("", "test-bp-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpBp.Name())
 
@@ -194,13 +194,13 @@ version = "*"`))
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, pushCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"id\": \"BlueprintsError\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"400 Bad Request:")
 	assert.Contains(t, string(stdout), "\"status\": 400")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)

--- a/cmd/composer-cli/blueprints/save_test.go
+++ b/cmd/composer-cli/blueprints/save_test.go
@@ -6,7 +6,7 @@ package blueprints
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -20,7 +20,7 @@ import (
 // Check the saved toml file to make sure the uid and gid are not floats
 // This function takes the simple approach and looks for strings.
 func checkUIDGidFloat(t *testing.T, filename string) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	require.Nil(t, err)
 	assert.NotContains(t, string(data), "gid = 1001.0")
 	assert.NotContains(t, string(data), "uid = 1001.0")
@@ -49,11 +49,11 @@ uid = 1001
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(toml))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(toml))),
 		}, nil
 	})
 
-	dir, err := ioutil.TempDir("", "test-bp-save-*")
+	dir, err := os.MkdirTemp("", "test-bp-save-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -74,10 +74,10 @@ uid = 1001
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, saveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -112,11 +112,11 @@ uid = 1001
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(toml))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(toml))),
 		}, nil
 	})
 
-	dir, err := ioutil.TempDir("", "test-bp-save-*")
+	dir, err := os.MkdirTemp("", "test-bp-save-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -137,10 +137,10 @@ uid = 1001
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, saveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -173,11 +173,11 @@ func TestCmdBlueprintsSaveUnknown(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
-	dir, err := ioutil.TempDir("", "test-bp-save-*")
+	dir, err := os.MkdirTemp("", "test-bp-save-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -199,10 +199,10 @@ func TestCmdBlueprintsSaveUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, saveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "UnknownBlueprint: test-no-bp")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -278,11 +278,11 @@ uid = 1001
 		}
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(data))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(data))),
 		}, nil
 	})
 
-	dir, err := ioutil.TempDir("", "test-bp-save-*")
+	dir, err := os.MkdirTemp("", "test-bp-save-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -303,12 +303,12 @@ uid = 1001
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, saveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"simple\"")
 	assert.Contains(t, string(stdout), "\"changed\": false")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -339,11 +339,11 @@ func TestCmdBlueprintsSaveUnknownJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
-	dir, err := ioutil.TempDir("", "test-bp-save-*")
+	dir, err := os.MkdirTemp("", "test-bp-save-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -365,13 +365,13 @@ func TestCmdBlueprintsSaveUnknownJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, saveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownBlueprint\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"test-no-bp: \"")
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/info/test-no-bp\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/blueprints/show_test.go
+++ b/cmd/composer-cli/blueprints/show_test.go
@@ -6,7 +6,7 @@ package blueprints
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -31,7 +31,7 @@ version = "0.1.0"
 `
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(toml))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(toml))),
 		}, nil
 	})
 
@@ -43,14 +43,14 @@ version = "0.1.0"
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, showCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "simple blueprint")
 	assert.Contains(t, string(stdout), "bash")
 	assert.Contains(t, string(stdout), "0.1.0")
 	assert.Contains(t, string(stdout), "[[packages]]")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -86,7 +86,7 @@ func TestCmdBlueprintsShowJSON(t *testing.T) {
 }`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -98,14 +98,14 @@ func TestCmdBlueprintsShowJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, showCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"simple\"")
 	assert.Contains(t, string(stdout), "\"name\": \"bash\"")
 	assert.Contains(t, string(stdout), "\"changed\": false")
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/info/simple\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -127,7 +127,7 @@ func TestCmdBlueprintsShowError(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -138,10 +138,10 @@ func TestCmdBlueprintsShowError(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, showCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Equal(t, []byte(""), stdout)
 	assert.Nil(t, err)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "UnknownBlueprint:")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -163,7 +163,7 @@ func TestCmdBlueprintsShowErrorJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -175,13 +175,13 @@ func TestCmdBlueprintsShowErrorJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, showCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownBlueprint\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"unknown: \"")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/blueprints/info/unknown\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/blueprints/tag_test.go
+++ b/cmd/composer-cli/blueprints/tag_test.go
@@ -6,7 +6,7 @@ package blueprints
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -23,7 +23,7 @@ func TestCmdBlueprintsTag(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -35,10 +35,10 @@ func TestCmdBlueprintsTag(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, tagCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -52,7 +52,7 @@ func TestCmdBlueprintsTagJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -64,13 +64,13 @@ func TestCmdBlueprintsTagJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, tagCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": true")
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/tag/cli-test-bp-1\"")
 	assert.Contains(t, string(stdout), "\"method\": \"POST")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -90,7 +90,7 @@ func TestCmdBlueprintsTagUnknown(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -102,10 +102,10 @@ func TestCmdBlueprintsTagUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, tagCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "Unknown blueprint: foo-bp-1")
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -125,7 +125,7 @@ func TestCmdBlueprintsTagUnknownJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -137,7 +137,7 @@ func TestCmdBlueprintsTagUnknownJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, tagCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"id\": \"BlueprintsError\"")
@@ -145,7 +145,7 @@ func TestCmdBlueprintsTagUnknownJSON(t *testing.T) {
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/blueprints/tag/foo-bp-1\"")
 	assert.Contains(t, string(stdout), "\"method\": \"POST\"")
 	assert.Contains(t, string(stdout), "\"status\": 400")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)

--- a/cmd/composer-cli/blueprints/undo_test.go
+++ b/cmd/composer-cli/blueprints/undo_test.go
@@ -6,7 +6,7 @@ package blueprints
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -23,7 +23,7 @@ func TestCmdBlueprintsUndo(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -35,10 +35,10 @@ func TestCmdBlueprintsUndo(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, undoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -52,7 +52,7 @@ func TestCmdBlueprintsUndoJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -64,13 +64,13 @@ func TestCmdBlueprintsUndoJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, undoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": true")
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/undo/cli-test-bp-1/f1da83187730c5e65d5931e2811481c5fe3407e5\"")
 	assert.Contains(t, string(stdout), "\"method\": \"POST")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -92,7 +92,7 @@ func TestCmdBlueprintsUndoUnknownBlueprint(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -104,10 +104,10 @@ func TestCmdBlueprintsUndoUnknownBlueprint(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, undoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "Unknown blueprint")
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -129,7 +129,7 @@ func TestCmdBlueprintsUndoUnknownBlueprintJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -141,14 +141,14 @@ func TestCmdBlueprintsUndoUnknownBlueprintJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, undoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownCommit\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"Unknown blueprint\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/blueprints/undo/foo-bp-1/f1da83187730c5e65d5931e2811481c5fe3407e5\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)

--- a/cmd/composer-cli/blueprints/workspace.go
+++ b/cmd/composer-cli/blueprints/workspace.go
@@ -6,7 +6,6 @@ package blueprints
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -31,7 +30,7 @@ func init() {
 func workspace(cmd *cobra.Command, args []string) (rcErr error) {
 	files := root.GetCommaArgs(args)
 	for _, filename := range files {
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: Missing blueprint file: %s\n", filename)
 			rcErr = root.ExecutionError(cmd, "")

--- a/cmd/composer-cli/blueprints/workspace_test.go
+++ b/cmd/composer-cli/blueprints/workspace_test.go
@@ -6,7 +6,7 @@ package blueprints
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -23,12 +23,12 @@ func TestCmdBlueprintsWorkspace(t *testing.T) {
 		json := `{"status": true}`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpBp, err := ioutil.TempFile("", "test-bp-*.toml")
+	tmpBp, err := os.CreateTemp("", "test-bp-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpBp.Name())
 
@@ -48,10 +48,10 @@ version = "*"`))
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, workspaceCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -64,12 +64,12 @@ func TestCmdBlueprintsWorkspaceJSON(t *testing.T) {
 		json := `{"status": true}`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpBp, err := ioutil.TempFile("", "test-bp-*.toml")
+	tmpBp, err := os.CreateTemp("", "test-bp-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpBp.Name())
 
@@ -89,13 +89,13 @@ version = "*"`))
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, workspaceCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": true")
 	assert.Contains(t, string(stdout), "\"path\": \"/blueprints/workspace\"")
 	assert.Contains(t, string(stdout), "\"method\": \"POST\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -118,12 +118,12 @@ func TestCmdBlueprintsWorkspaceError(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpBp, err := ioutil.TempFile("", "test-bp-*.toml")
+	tmpBp, err := os.CreateTemp("", "test-bp-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpBp.Name())
 
@@ -143,10 +143,10 @@ version = "*"`))
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, workspaceCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "BlueprintsError")
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -169,12 +169,12 @@ func TestCmdBlueprintsWorkspaceErrorJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpBp, err := ioutil.TempFile("", "test-bp-*.toml")
+	tmpBp, err := os.CreateTemp("", "test-bp-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpBp.Name())
 
@@ -194,7 +194,7 @@ version = "*"`))
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, workspaceCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"id\": \"BlueprintsError\"")
@@ -202,7 +202,7 @@ version = "*"`))
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/blueprints/workspace\"")
 	assert.Contains(t, string(stdout), "\"method\": \"POST\"")
 	assert.Contains(t, string(stdout), "\"status\": 400")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)

--- a/cmd/composer-cli/compose/cancel_test.go
+++ b/cmd/composer-cli/compose/cancel_test.go
@@ -6,7 +6,7 @@ package compose
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -31,7 +31,7 @@ func TestCmdComposeCancel(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -44,14 +44,14 @@ func TestCmdComposeCancel(t *testing.T) {
 	assert.Equal(t, cmd, cancelCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(""), sentBody)
@@ -73,7 +73,7 @@ func TestCmdComposeCancelJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -86,18 +86,18 @@ func TestCmdComposeCancelJSON(t *testing.T) {
 	assert.Equal(t, cmd, cancelCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": true")
 	assert.Contains(t, string(stdout), "\"uuid\": \"ac188b76-138a-452c-82fb-5cc651986991\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/compose/cancel/ac188b76-138a-452c-82fb-5cc651986991\"")
 	assert.Contains(t, string(stdout), "\"method\": \"DELETE")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(""), sentBody)
@@ -120,7 +120,7 @@ func TestCmdComposeCancelUnknown(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -134,14 +134,14 @@ func TestCmdComposeCancelUnknown(t *testing.T) {
 	assert.Equal(t, cmd, cancelCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("ERROR: UnknownUUID: Compose 4b668b1a-e6b8-4dce-8828-4a8e3bef2345 doesn't exist\n"), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(""), sentBody)
@@ -164,7 +164,7 @@ func TestCmdComposeCancelUnknownJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -178,18 +178,18 @@ func TestCmdComposeCancelUnknownJSON(t *testing.T) {
 	assert.Equal(t, cmd, cancelCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/compose/cancel/4b668b1a-e6b8-4dce-8828-4a8e3bef2345\"")
 	assert.Contains(t, string(stdout), "\"method\": \"DELETE")
 	assert.Contains(t, string(stdout), "\"status\": 400")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(""), sentBody)

--- a/cmd/composer-cli/compose/delete_test.go
+++ b/cmd/composer-cli/compose/delete_test.go
@@ -6,7 +6,7 @@ package compose
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -31,7 +31,7 @@ func TestCmdComposeDelete(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -44,14 +44,14 @@ func TestCmdComposeDelete(t *testing.T) {
 	assert.Equal(t, cmd, deleteCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(""), sentBody)
@@ -73,7 +73,7 @@ func TestCmdComposeDeleteJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -86,17 +86,17 @@ func TestCmdComposeDeleteJSON(t *testing.T) {
 	assert.Equal(t, cmd, deleteCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": true")
 	assert.Contains(t, string(stdout), "\"uuid\": \"ac188b76-138a-452c-82fb-5cc651986991\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/compose/delete/ac188b76-138a-452c-82fb-5cc651986991\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(""), sentBody)
@@ -123,7 +123,7 @@ func TestCmdComposeDeleteUnknown(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -136,14 +136,14 @@ func TestCmdComposeDeleteUnknown(t *testing.T) {
 	assert.Equal(t, cmd, deleteCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("ERROR: UnknownUUID: compose 4b668b1a-e6b8-4dce-8828-4a8e3bef2345 doesn't exist\n"), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(""), sentBody)
@@ -170,7 +170,7 @@ func TestCmdComposeDeleteUnknownJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -183,7 +183,7 @@ func TestCmdComposeDeleteUnknownJSON(t *testing.T) {
 	assert.Equal(t, cmd, deleteCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": true")
@@ -191,11 +191,11 @@ func TestCmdComposeDeleteUnknownJSON(t *testing.T) {
 	assert.Contains(t, string(stdout), "\"path\": \"/compose/delete/ac188b76-138a-452c-82fb-5cc651986991,4b668b1a-e6b8-4dce-8828-4a8e3bef2345\"")
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownUUID\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"compose 4b668b1a-e6b8-4dce-8828-4a8e3bef2345 doesn't exist\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(""), sentBody)

--- a/cmd/composer-cli/compose/image_test.go
+++ b/cmd/composer-cli/compose/image_test.go
@@ -7,7 +7,7 @@ package compose
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -25,7 +25,7 @@ func TestCmdComposeImage(t *testing.T) {
 
 		resp := http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(data))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(data))),
 			Header:     http.Header{},
 		}
 		resp.Header.Set("Content-Disposition", "attachment; filename=b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7.qcow2")
@@ -36,7 +36,7 @@ func TestCmdComposeImage(t *testing.T) {
 	})
 
 	// Change to a temporary directory for the file to be saved in
-	dir, err := ioutil.TempDir("", "test-image-*")
+	dir, err := os.MkdirTemp("", "test-image-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -57,10 +57,10 @@ func TestCmdComposeImage(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, imageCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7.qcow2")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -77,7 +77,7 @@ func TestCmdComposeImageFilename(t *testing.T) {
 
 		resp := http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(data))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(data))),
 			Header:     http.Header{},
 		}
 		resp.Header.Set("Content-Disposition", "attachment; filename=b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7.qcow2")
@@ -88,7 +88,7 @@ func TestCmdComposeImageFilename(t *testing.T) {
 	})
 
 	// Change to a temporary directory for the file to be saved in
-	dir, err := ioutil.TempDir("", "test-image-*")
+	dir, err := os.MkdirTemp("", "test-image-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -109,10 +109,10 @@ func TestCmdComposeImageFilename(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, imageCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "test-compose-image.qcow2")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -138,13 +138,13 @@ func TestCmdComposeUnknownImage(t *testing.T) {
 		resp := http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}
 		return &resp, nil
 	})
 
 	// Change to a temporary directory for the file to be saved in
-	dir, err := ioutil.TempDir("", "test-image-*")
+	dir, err := os.MkdirTemp("", "test-image-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -167,10 +167,10 @@ func TestCmdComposeUnknownImage(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, imageCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "UnknownUUID: c3660d9b-8d8b-4077-8b9a-72e4f5861f4 is not a valid build uuid")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -196,13 +196,13 @@ func TestCmdComposeUnknownImageJSON(t *testing.T) {
 		resp := http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}
 		return &resp, nil
 	})
 
 	// Change to a temporary directory for the file to be saved in
-	dir, err := ioutil.TempDir("", "test-image-*")
+	dir, err := os.MkdirTemp("", "test-image-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -225,7 +225,7 @@ func TestCmdComposeUnknownImageJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, imageCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownUUID\"")
@@ -233,7 +233,7 @@ func TestCmdComposeUnknownImageJSON(t *testing.T) {
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/compose/image/b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7\"")
 	assert.Contains(t, string(stdout), "\"status\": 400")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/compose/info_test.go
+++ b/cmd/composer-cli/compose/info_test.go
@@ -6,7 +6,7 @@ package compose
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -69,7 +69,7 @@ func TestCmdComposeInfo(t *testing.T) {
 }`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -82,13 +82,13 @@ func TestCmdComposeInfo(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "ddcf50e5-1ffa-4de6-95ed-42749ac1f389")
 	assert.Contains(t, string(stdout), "FINISHED")
 	assert.Contains(t, string(stdout), "bash-*")
 	assert.Contains(t, string(stdout), "chrony-4.0-1.fc33.x86_64")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -147,7 +147,7 @@ func TestCmdComposeInfoJSON(t *testing.T) {
 }`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -160,13 +160,13 @@ func TestCmdComposeInfoJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"id\": \"ddcf50e5-1ffa-4de6-95ed-42749ac1f389\"")
 	assert.Contains(t, string(stdout), "\"queue_status\": \"FINISHED\"")
 	assert.Contains(t, string(stdout), "\"name\": \"chrony\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -187,7 +187,7 @@ func TestCmdComposeInfoUnknown(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -201,10 +201,10 @@ func TestCmdComposeInfoUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "UnknownUUID: 328e96c9-41d7-423f-92ec-94e390c093ac is not")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -225,7 +225,7 @@ func TestCmdComposeInfoUnknownJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -239,14 +239,14 @@ func TestCmdComposeInfoUnknownJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownUUID\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"328e96c9-41d7-423f-92ec-94e390c093ac is not a valid build uuid\"")
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/compose/info/328e96c9-41d7-423f-92ec-94e390c093ac\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/compose/list_test.go
+++ b/cmd/composer-cli/compose/list_test.go
@@ -6,7 +6,7 @@ package compose
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -82,7 +82,7 @@ func TestCmdComposeList(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -95,13 +95,13 @@ func TestCmdComposeList(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7")
 	assert.Contains(t, string(stdout), "6d185e04-b56e-4705-97b6-21d6c6c85f06")
 	assert.Contains(t, string(stdout), "cefd01c3-629f-493e-af72-3f12981bb77b")
 	assert.Contains(t, string(stdout), "d5903571-55e2-4a18-8643-2d90611fcb11")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -115,13 +115,13 @@ func TestCmdComposeList(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err = ioutil.ReadAll(out.Stdout)
+	stdout, err = io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7")
 	assert.Contains(t, string(stdout), "6d185e04-b56e-4705-97b6-21d6c6c85f06")
 	assert.NotContains(t, string(stdout), "cefd01c3-629f-493e-af72-3f12981bb77b")
 	assert.NotContains(t, string(stdout), "d5903571-55e2-4a18-8643-2d90611fcb11")
-	stderr, err = ioutil.ReadAll(out.Stderr)
+	stderr, err = io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -135,13 +135,13 @@ func TestCmdComposeList(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err = ioutil.ReadAll(out.Stdout)
+	stdout, err = io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7")
 	assert.NotContains(t, string(stdout), "6d185e04-b56e-4705-97b6-21d6c6c85f06")
 	assert.Contains(t, string(stdout), "cefd01c3-629f-493e-af72-3f12981bb77b")
 	assert.NotContains(t, string(stdout), "d5903571-55e2-4a18-8643-2d90611fcb11")
-	stderr, err = ioutil.ReadAll(out.Stderr)
+	stderr, err = io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -155,13 +155,13 @@ func TestCmdComposeList(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err = ioutil.ReadAll(out.Stdout)
+	stdout, err = io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7")
 	assert.NotContains(t, string(stdout), "6d185e04-b56e-4705-97b6-21d6c6c85f06")
 	assert.NotContains(t, string(stdout), "cefd01c3-629f-493e-af72-3f12981bb77b")
 	assert.Contains(t, string(stdout), "d5903571-55e2-4a18-8643-2d90611fcb11")
-	stderr, err = ioutil.ReadAll(out.Stderr)
+	stderr, err = io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -175,13 +175,13 @@ func TestCmdComposeList(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err = ioutil.ReadAll(out.Stdout)
+	stdout, err = io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7")
 	assert.NotContains(t, string(stdout), "6d185e04-b56e-4705-97b6-21d6c6c85f06")
 	assert.Contains(t, string(stdout), "cefd01c3-629f-493e-af72-3f12981bb77b")
 	assert.Contains(t, string(stdout), "d5903571-55e2-4a18-8643-2d90611fcb11")
-	stderr, err = ioutil.ReadAll(out.Stderr)
+	stderr, err = io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -253,7 +253,7 @@ func TestCmdComposeListJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -266,14 +266,14 @@ func TestCmdComposeListJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"id\": \"b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7\"")
 	assert.Contains(t, string(stdout), "\"id\": \"6d185e04-b56e-4705-97b6-21d6c6c85f06\"")
 	assert.Contains(t, string(stdout), "\"id\": \"cefd01c3-629f-493e-af72-3f12981bb77b\"")
 	assert.Contains(t, string(stdout), "\"id\": \"d5903571-55e2-4a18-8643-2d90611fcb11\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/compose/log_test.go
+++ b/cmd/composer-cli/compose/log_test.go
@@ -6,7 +6,7 @@ package compose
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -25,7 +25,7 @@ And should do the job.`
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(log))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(log))),
 		}, nil
 	})
 
@@ -38,10 +38,10 @@ And should do the job.`
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, logCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "approximation")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -56,10 +56,10 @@ And should do the job.`
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, logCmd)
-	stdout, err = ioutil.ReadAll(out.Stdout)
+	stdout, err = io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "approximation")
-	stderr, err = ioutil.ReadAll(out.Stderr)
+	stderr, err = io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -79,7 +79,7 @@ func TestCmdComposeLogUnknown(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -92,10 +92,10 @@ func TestCmdComposeLogUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, logCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "4b668b1a-e6b8-4dce-8828-4a8e3bef2345 is not a valid")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -112,7 +112,7 @@ func TestCmdComposeLogUnknownJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -126,14 +126,14 @@ func TestCmdComposeLogUnknownJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, logCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownUUID\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"4b668b1a-e6b8-4dce-8828-4a8e3bef2345 is not a valid build uuid\"")
 	assert.Contains(t, string(stdout), "\"status\": 400")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/compose/logs_test.go
+++ b/cmd/composer-cli/compose/logs_test.go
@@ -6,7 +6,7 @@ package compose
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -29,7 +29,7 @@ And should do the job.`
 
 		resp := http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader(tar)),
+			Body:       io.NopCloser(bytes.NewReader(tar)),
 			Header:     http.Header{},
 		}
 		resp.Header.Set("Content-Disposition", "attachment; filename=b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7-logs.tar")
@@ -39,7 +39,7 @@ And should do the job.`
 	})
 
 	// Change to a temporary directory for the file to be saved in
-	dir, err := ioutil.TempDir("", "test-logs-*")
+	dir, err := os.MkdirTemp("", "test-logs-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -60,10 +60,10 @@ And should do the job.`
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, logsCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7-logs.tar")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -85,7 +85,7 @@ And should do the job.`
 
 		resp := http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader(tar)),
+			Body:       io.NopCloser(bytes.NewReader(tar)),
 			Header:     http.Header{},
 		}
 		resp.Header.Set("Content-Disposition", "attachment; filename=b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7-logs.tar")
@@ -95,7 +95,7 @@ And should do the job.`
 	})
 
 	// Change to a temporary directory for the file to be saved in
-	dir, err := ioutil.TempDir("", "test-logs-*")
+	dir, err := os.MkdirTemp("", "test-logs-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -116,10 +116,10 @@ And should do the job.`
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, logsCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "test-compose-logs.tar")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -140,7 +140,7 @@ func TestCmdComposeLogsUnknown(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -157,10 +157,10 @@ func TestCmdComposeLogsUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, logsCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "ERROR: UnknownUUID: 4b668b1a-e6b8-4dce-8828-4a8e3bef2345 is not a valid build uuid")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -177,7 +177,7 @@ func TestCmdComposeLogsUnknownJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -194,14 +194,14 @@ func TestCmdComposeLogsUnknownJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, logsCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownUUID\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"4b668b1a-e6b8-4dce-8828-4a8e3bef2345 is not a valid build uuid\"")
 	assert.Contains(t, string(stdout), "\"status\": 400")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/compose/metadata_test.go
+++ b/cmd/composer-cli/compose/metadata_test.go
@@ -6,7 +6,7 @@ package compose
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -29,7 +29,7 @@ And should do the job.`
 
 		resp := http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader(tar)),
+			Body:       io.NopCloser(bytes.NewReader(tar)),
 			Header:     http.Header{},
 		}
 		resp.Header.Set("Content-Disposition", "attachment; filename=b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7-metadata.tar")
@@ -39,7 +39,7 @@ And should do the job.`
 	})
 
 	// Change to a temporary directory for the file to be saved in
-	dir, err := ioutil.TempDir("", "test-metadata-*")
+	dir, err := os.MkdirTemp("", "test-metadata-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -61,10 +61,10 @@ And should do the job.`
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, metadataCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7-metadata.tar")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -86,7 +86,7 @@ And should do the job.`
 
 		resp := http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader(tar)),
+			Body:       io.NopCloser(bytes.NewReader(tar)),
 			Header:     http.Header{},
 		}
 		resp.Header.Set("Content-Disposition", "attachment; filename=b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7-metadata.tar")
@@ -96,7 +96,7 @@ And should do the job.`
 	})
 
 	// Change to a temporary directory for the file to be saved in
-	dir, err := ioutil.TempDir("", "test-metadata-*")
+	dir, err := os.MkdirTemp("", "test-metadata-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -118,10 +118,10 @@ And should do the job.`
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, metadataCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "test-compose-metadata.tar")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -142,7 +142,7 @@ func TestCmdComposeMetadataUnknown(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -159,10 +159,10 @@ func TestCmdComposeMetadataUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, metadataCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "UnknownUUID: b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7 is not a valid build uuid")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -179,7 +179,7 @@ func TestCmdComposeMetadataUnknownJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -196,14 +196,14 @@ func TestCmdComposeMetadataUnknownJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, metadataCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownUUID\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7 is not a valid build uuid\"")
 	assert.Contains(t, string(stdout), "\"status\": 400")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/compose/results_test.go
+++ b/cmd/composer-cli/compose/results_test.go
@@ -6,7 +6,7 @@ package compose
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -29,7 +29,7 @@ And should do the job.`
 
 		resp := http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader(tar)),
+			Body:       io.NopCloser(bytes.NewReader(tar)),
 			Header:     http.Header{},
 		}
 		resp.Header.Set("Content-Disposition", "attachment; filename=b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7.tar")
@@ -39,7 +39,7 @@ And should do the job.`
 	})
 
 	// Change to a temporary directory for the file to be saved in
-	dir, err := ioutil.TempDir("", "test-results-*")
+	dir, err := os.MkdirTemp("", "test-results-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -60,10 +60,10 @@ And should do the job.`
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, resultsCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7.tar")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -85,7 +85,7 @@ And should do the job.`
 
 		resp := http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader(tar)),
+			Body:       io.NopCloser(bytes.NewReader(tar)),
 			Header:     http.Header{},
 		}
 		resp.Header.Set("Content-Disposition", "attachment; filename=b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7.tar")
@@ -95,7 +95,7 @@ And should do the job.`
 	})
 
 	// Change to a temporary directory for the file to be saved in
-	dir, err := ioutil.TempDir("", "test-results-*")
+	dir, err := os.MkdirTemp("", "test-results-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -116,10 +116,10 @@ And should do the job.`
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, resultsCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "test-compose-results.tar")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -140,7 +140,7 @@ func TestCmdComposeResultsUnknown(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -157,10 +157,10 @@ func TestCmdComposeResultsUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, resultsCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "UnknownUUID: b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7 is not a valid build uuid")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -177,7 +177,7 @@ func TestCmdComposeResultsUnknownJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -194,14 +194,14 @@ func TestCmdComposeResultsUnknownJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, resultsCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownUUID\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"b27c5a7b-d1f6-4c8c-8526-6d6de464f1c7 is not a valid build uuid\"")
 	assert.Contains(t, string(stdout), "\"status\": 400")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/compose/start_ostree_test.go
+++ b/cmd/composer-cli/compose/start_ostree_test.go
@@ -6,7 +6,7 @@ package compose
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -27,7 +27,7 @@ func TestCmdComposeStartOSTree(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -46,14 +46,14 @@ func TestCmdComposeStartOSTree(t *testing.T) {
 	assert.Equal(t, cmd, startOSTreeCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("Compose 876b2946-16cd-4f38-bace-0cdd0093d112 added to the queue\n"), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"parentid","url":""}}`), sentBody)
@@ -71,7 +71,7 @@ func TestCmdComposeStartOSTreeJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -90,17 +90,17 @@ func TestCmdComposeStartOSTreeJSON(t *testing.T) {
 	assert.Equal(t, cmd, startOSTreeCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": true")
 	assert.Contains(t, string(stdout), "\"build_id\": \"876b2946-16cd-4f38-bace-0cdd0093d112\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/compose\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"parentid","url":""}}`), sentBody)
@@ -124,7 +124,7 @@ func TestCmdComposeStartOSTreeUnknown(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -144,14 +144,14 @@ func TestCmdComposeStartOSTreeUnknown(t *testing.T) {
 	assert.Equal(t, cmd, startOSTreeCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "UnknownBlueprint: Unknown blueprint name: missing-server")
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"missing-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"parentid","url":""}}`), sentBody)
@@ -175,7 +175,7 @@ func TestCmdComposeStartOSTreeUnknownJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -195,7 +195,7 @@ func TestCmdComposeStartOSTreeUnknownJSON(t *testing.T) {
 	assert.Equal(t, cmd, startOSTreeCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
@@ -203,11 +203,11 @@ func TestCmdComposeStartOSTreeUnknownJSON(t *testing.T) {
 	assert.Contains(t, string(stdout), "\"msg\": \"Unknown blueprint name: missing-server\"")
 	assert.Contains(t, string(stdout), "\"status\": 400")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/compose\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"missing-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"parentid","url":""}}`), sentBody)
@@ -225,7 +225,7 @@ func TestCmdComposeStartOSTreeURL(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -244,14 +244,14 @@ func TestCmdComposeStartOSTreeURL(t *testing.T) {
 	assert.Equal(t, cmd, startOSTreeCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("Compose 876b2946-16cd-4f38-bace-0cdd0093d112 added to the queue\n"), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"","url":"http://ostree-url"}}`), sentBody)
@@ -275,7 +275,7 @@ func TestCmdComposeStartOSTreeURLUnknown(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -295,14 +295,14 @@ func TestCmdComposeStartOSTreeURLUnknown(t *testing.T) {
 	assert.Equal(t, cmd, startOSTreeCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "OSTreeCommitError: ")
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"","url":"http://not-ostree-url"}}`), sentBody)
@@ -326,7 +326,7 @@ func TestCmdComposeStartOSTreeURLUnknownJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -346,17 +346,17 @@ func TestCmdComposeStartOSTreeURLUnknownJSON(t *testing.T) {
 	assert.Equal(t, cmd, startOSTreeCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"OSTreeCommitError\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/compose\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"","url":"http://not-ostree-url"}}`), sentBody)
@@ -374,7 +374,7 @@ func TestCmdComposeStartOSTreeSize(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -393,14 +393,14 @@ func TestCmdComposeStartOSTreeSize(t *testing.T) {
 	assert.Equal(t, cmd, startOSTreeCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("Compose 876b2946-16cd-4f38-bace-0cdd0093d112 added to the queue\n"), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":998,"ostree":{"ref":"refid","parent":"parentid","url":""}}`), sentBody)
@@ -418,12 +418,12 @@ func TestCmdComposeStartOSTreeUpload(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpProfile, err := ioutil.TempFile("", "test-profile-p*.toml")
+	tmpProfile, err := os.CreateTemp("", "test-profile-p*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpProfile.Name())
 
@@ -451,14 +451,14 @@ aws_secret_key = "AWS Secret Key"
 	assert.Equal(t, cmd, startOSTreeCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("Compose 876b2946-16cd-4f38-bace-0cdd0093d112 added to the queue\n"), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0,"ostree":{"ref":"refid","parent":"parentid","url":""},"upload":{"provider":"aws","image_name":"httpimage","settings":{"aws_access_key":"AWS Access Key","aws_bucket":"AWS Bucket","aws_region":"AWS Region","aws_secret_key":"AWS Secret Key"}}}`), sentBody)
@@ -487,10 +487,10 @@ func TestCmdComposeStartOSTreeUploadUnknown(t *testing.T) {
 	assert.Equal(t, cmd, startOSTreeCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 }

--- a/cmd/composer-cli/compose/start_test.go
+++ b/cmd/composer-cli/compose/start_test.go
@@ -6,7 +6,7 @@ package compose
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -27,7 +27,7 @@ func TestCmdComposeStart(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -42,14 +42,14 @@ func TestCmdComposeStart(t *testing.T) {
 	assert.Equal(t, cmd, startCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("Compose 876b2946-16cd-4f38-bace-0cdd0093d112 added to the queue\n"), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0}`), sentBody)
@@ -67,7 +67,7 @@ func TestCmdComposeStartJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -82,17 +82,17 @@ func TestCmdComposeStartJSON(t *testing.T) {
 	assert.Equal(t, cmd, startCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": true")
 	assert.Contains(t, string(stdout), "\"build_id\": \"876b2946-16cd-4f38-bace-0cdd0093d112\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/compose\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0}`), sentBody)
@@ -110,7 +110,7 @@ func TestCmdComposeStartSize(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -125,14 +125,14 @@ func TestCmdComposeStartSize(t *testing.T) {
 	assert.Equal(t, cmd, startCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("Compose 876b2946-16cd-4f38-bace-0cdd0093d112 added to the queue\n"), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":998}`), sentBody)
@@ -150,12 +150,12 @@ func TestCmdComposeStartUpload(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpProfile, err := ioutil.TempFile("", "test-profile-p*.toml")
+	tmpProfile, err := os.CreateTemp("", "test-profile-p*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpProfile.Name())
 
@@ -179,14 +179,14 @@ aws_secret_key = "AWS Secret Key"
 	assert.Equal(t, cmd, startCmd)
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("Compose 876b2946-16cd-4f38-bace-0cdd0093d112 added to the queue\n"), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte(`{"blueprint_name":"http-server","compose_type":"qcow2","branch":"master","size":0,"upload":{"provider":"aws","image_name":"httpimage","settings":{"aws_access_key":"AWS Access Key","aws_bucket":"AWS Bucket","aws_region":"AWS Region","aws_secret_key":"AWS Secret Key"}}}`), sentBody)

--- a/cmd/composer-cli/compose/status_test.go
+++ b/cmd/composer-cli/compose/status_test.go
@@ -6,7 +6,7 @@ package compose
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -93,7 +93,7 @@ func TestCmdComposeStatus(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -106,7 +106,7 @@ func TestCmdComposeStatus(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, statusCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 
 	// Check for expected output, but not exact match due to local time being used.
@@ -118,7 +118,7 @@ func TestCmdComposeStatus(t *testing.T) {
 
 		assert.Contains(t, string(stdout), s)
 	}
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -201,7 +201,7 @@ func TestCmdComposeStatusJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -214,7 +214,7 @@ func TestCmdComposeStatusJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, statusCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"id\": \"6d185e04-b56e-4705-97b6-21d6c6c85f06\"")
@@ -224,7 +224,7 @@ func TestCmdComposeStatusJSON(t *testing.T) {
 	assert.Contains(t, string(stdout), "\"path\": \"/compose/queue\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/compose/finished\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/compose/failed\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/compose/types_test.go
+++ b/cmd/composer-cli/compose/types_test.go
@@ -6,7 +6,7 @@ package compose
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -50,7 +50,7 @@ func TestCmdComposeTypes(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -63,11 +63,11 @@ func TestCmdComposeTypes(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, typesCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "openstack")
 	assert.Contains(t, string(stdout), "qcow2")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -107,7 +107,7 @@ func TestCmdComposeTypesJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -120,13 +120,13 @@ func TestCmdComposeTypesJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, typesCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"openstack\"")
 	assert.Contains(t, string(stdout), "\"name\": \"qcow2\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/compose/types\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -150,7 +150,7 @@ func TestCmdComposeTypesDistro(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -163,11 +163,11 @@ func TestCmdComposeTypesDistro(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, typesCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "tar")
 	assert.Contains(t, string(stdout), "qcow2")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -191,7 +191,7 @@ func TestCmdComposeTypesDistroJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -204,13 +204,13 @@ func TestCmdComposeTypesDistroJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, typesCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"tar\"")
 	assert.Contains(t, string(stdout), "\"name\": \"qcow2\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/compose/types?distro=test-distro\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -232,7 +232,7 @@ func TestCmdComposeTypesBadDistro(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -245,10 +245,10 @@ func TestCmdComposeTypesBadDistro(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, typesCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "DistroError: Invalid distro: homer")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -270,7 +270,7 @@ func TestCmdComposeTypesBadDistroJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -283,12 +283,12 @@ func TestCmdComposeTypesBadDistroJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, typesCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"id\": \"DistroError\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"Invalid distro: homer\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/distros/list_test.go
+++ b/cmd/composer-cli/distros/list_test.go
@@ -6,7 +6,7 @@ package distros
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -23,7 +23,7 @@ func TestCmdDistrosList(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -36,12 +36,12 @@ func TestCmdDistrosList(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "centos-8")
 	assert.Contains(t, string(stdout), "fedora-33")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -54,7 +54,7 @@ func TestCmdDistrosListJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -67,13 +67,13 @@ func TestCmdDistrosListJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "\"centos-8\"")
 	assert.Contains(t, string(stdout), "\"fedora-33\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/modules/info_test.go
+++ b/cmd/composer-cli/modules/info_test.go
@@ -6,7 +6,7 @@ package modules
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -72,7 +72,7 @@ func TestCmdModulesInfo(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -85,13 +85,13 @@ func TestCmdModulesInfo(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "Summary: The GNU Bourne Again shell")
 	assert.Contains(t, string(stdout), "             shell (sh). Bash")
 	assert.Contains(t, string(stdout), "     5.0.17-2.fc33.x86_64 at")
 	assert.Contains(t, string(stdout), "     basesystem-11-10.fc33.noarch")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -154,7 +154,7 @@ func TestCmdModulesInfoJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -167,13 +167,13 @@ func TestCmdModulesInfoJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"description\": \"The GNU Bourne Again shell")
 	assert.Contains(t, string(stdout), "\"version\": \"5.0.17\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/modules/info/bash\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -196,7 +196,7 @@ func TestCmdModulesInfoUnknown(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -210,10 +210,10 @@ func TestCmdModulesInfoUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "UnknownModule: No packages have been found")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -236,7 +236,7 @@ func TestCmdModulesInfoUnknownJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -250,14 +250,14 @@ func TestCmdModulesInfoUnknownJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownModule\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"No packages have been found.\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/modules/info/mash\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -320,7 +320,7 @@ func TestCmdModulesInfoDistro(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -333,13 +333,13 @@ func TestCmdModulesInfoDistro(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "Summary: The GNU Bourne Again shell")
 	assert.Contains(t, string(stdout), "             shell (sh). Bash")
 	assert.Contains(t, string(stdout), "     5.0.17-2.fc33.x86_64 at")
 	assert.Contains(t, string(stdout), "     basesystem-11-10.fc33.noarch")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -402,7 +402,7 @@ func TestCmdModulesInfoDistroJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -415,13 +415,13 @@ func TestCmdModulesInfoDistroJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"description\": \"The GNU Bourne Again shell")
 	assert.Contains(t, string(stdout), "\"version\": \"5.0.17\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/modules/info/bash?distro=test-distro\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -444,7 +444,7 @@ func TestCmdModulesInfoBadDistro(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -458,10 +458,10 @@ func TestCmdModulesInfoBadDistro(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "DistroError: Invalid distro: homer")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -483,7 +483,7 @@ func TestCmdModulesInfoBadDistroJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -497,14 +497,14 @@ func TestCmdModulesInfoBadDistroJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"DistroError\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"Invalid distro: homer\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/modules/info/bash?distro=homer\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/modules/list_test.go
+++ b/cmd/composer-cli/modules/list_test.go
@@ -6,7 +6,7 @@ package modules
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -35,7 +35,7 @@ func TestCmdModulesList(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -48,11 +48,11 @@ func TestCmdModulesList(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "http-server-prod")
 	assert.Contains(t, string(stdout), "nfs-server-test")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -77,7 +77,7 @@ func TestCmdModulesListJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -90,13 +90,13 @@ func TestCmdModulesListJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"http-server-prod\"")
 	assert.Contains(t, string(stdout), "\"name\": \"nfs-server-test\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/modules/list?limit=0\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -121,7 +121,7 @@ func TestCmdModulesListDistro(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -134,11 +134,11 @@ func TestCmdModulesListDistro(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "http-server-prod")
 	assert.Contains(t, string(stdout), "nfs-server-test")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -163,7 +163,7 @@ func TestCmdModulesListDistroJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -176,13 +176,13 @@ func TestCmdModulesListDistroJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"http-server-prod\"")
 	assert.Contains(t, string(stdout), "\"name\": \"nfs-server-test\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/modules/list?distro=test-distro\\u0026limit=0\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -205,7 +205,7 @@ func TestCmdModulesListBadDistro(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -219,10 +219,10 @@ func TestCmdModulesListBadDistro(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "DistroError: Invalid distro: homer")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -244,7 +244,7 @@ func TestCmdModulesListBadDistroJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -258,14 +258,14 @@ func TestCmdModulesListBadDistroJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"DistroError\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"Invalid distro: homer\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/modules/list?distro=homer\\u0026limit=0\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/projects/depsolve_test.go
+++ b/cmd/composer-cli/projects/depsolve_test.go
@@ -6,7 +6,7 @@ package projects
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -44,7 +44,7 @@ func TestCmdProjectsDepsolve(t *testing.T) {
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -56,12 +56,12 @@ func TestCmdProjectsDepsolve(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, depsolveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "acl-2.2.53-9.fc33.x86_64")
 	assert.Contains(t, string(stdout), "basesystem-11-10.fc33.noarch")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -95,7 +95,7 @@ func TestCmdProjectsDepsolveJSON(t *testing.T) {
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -107,13 +107,13 @@ func TestCmdProjectsDepsolveJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, depsolveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"basesystem\"")
 	assert.Contains(t, string(stdout), "\"version\": \"2.2.53\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/projects/depsolve/bash\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -147,7 +147,7 @@ func TestCmdProjectsDepsolveDistro(t *testing.T) {
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -159,12 +159,12 @@ func TestCmdProjectsDepsolveDistro(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, depsolveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotContains(t, string(stdout), "{")
 	assert.Contains(t, string(stdout), "acl-2.2.53-9.fc33.x86_64")
 	assert.Contains(t, string(stdout), "basesystem-11-10.fc33.noarch")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -198,7 +198,7 @@ func TestCmdProjectsDepsolveDistroJSON(t *testing.T) {
 	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -210,13 +210,13 @@ func TestCmdProjectsDepsolveDistroJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, depsolveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"basesystem\"")
 	assert.Contains(t, string(stdout), "\"version\": \"2.2.53\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/projects/depsolve/bash?distro=test-distro\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -238,7 +238,7 @@ func TestCmdProjectsDepsolveBadDistro(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -251,10 +251,10 @@ func TestCmdProjectsDepsolveBadDistro(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, depsolveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "DistroError: Invalid distro: homer")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -276,7 +276,7 @@ func TestCmdProjectsDepsolveBadDistroJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -289,14 +289,14 @@ func TestCmdProjectsDepsolveBadDistroJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, depsolveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"DistroError\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"Invalid distro: homer\"")
 	assert.Contains(t, string(stdout), "\"status\": 400")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -317,7 +317,7 @@ func TestCmdProjectsDepsolveUnknown(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -330,10 +330,10 @@ func TestCmdProjectsDepsolveUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, depsolveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "missing packages: homer")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -354,7 +354,7 @@ func TestCmdProjectsDepsolveUnknownJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -367,14 +367,14 @@ func TestCmdProjectsDepsolveUnknownJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, depsolveCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"ProjectsError\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"BadRequest: DNF error occured")
 	assert.Contains(t, string(stdout), "\"status\": 400")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/projects/info_test.go
+++ b/cmd/composer-cli/projects/info_test.go
@@ -6,7 +6,7 @@ package projects
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -50,7 +50,7 @@ func TestCmdProjectsInfo(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -62,12 +62,12 @@ func TestCmdProjectsInfo(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "Summary: The GNU Bourne Again shell")
 	assert.Contains(t, string(stdout), "             shell (sh). Bash")
 	assert.Contains(t, string(stdout), "     5.0.17-2.fc33.x86_64 at")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -108,7 +108,7 @@ func TestCmdProjectsInfoJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -120,13 +120,13 @@ func TestCmdProjectsInfoJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"description\": \"The GNU Bourne Again shell")
 	assert.Contains(t, string(stdout), "\"version\": \"5.0.17\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/projects/info/bash\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -149,7 +149,7 @@ func TestCmdModulesInfoUnknown(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -163,10 +163,10 @@ func TestCmdModulesInfoUnknown(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "UnknownProject: No packages have been found")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -189,7 +189,7 @@ func TestCmdModulesInfoUnknownJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -203,14 +203,14 @@ func TestCmdModulesInfoUnknownJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownProject\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"No packages have been found.\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/projects/info/mash\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -251,7 +251,7 @@ func TestCmdProjectsInfoDistro(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -263,12 +263,12 @@ func TestCmdProjectsInfoDistro(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "Summary: The GNU Bourne Again shell")
 	assert.Contains(t, string(stdout), "             shell (sh). Bash")
 	assert.Contains(t, string(stdout), "     5.0.17-2.fc33.x86_64 at")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -309,7 +309,7 @@ func TestCmdProjectsInfoDistroJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -321,13 +321,13 @@ func TestCmdProjectsInfoDistroJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"description\": \"The GNU Bourne Again shell")
 	assert.Contains(t, string(stdout), "\"version\": \"5.0.17\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/projects/info/bash?distro=test-distro\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -350,7 +350,7 @@ func TestCmdProjectsInfoBadDistro(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -363,10 +363,10 @@ func TestCmdProjectsInfoBadDistro(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "DistroError: Invalid distro: homer")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -388,7 +388,7 @@ func TestCmdProjectsInfoBadDistroJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -401,14 +401,14 @@ func TestCmdProjectsInfoBadDistroJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"DistroError\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"Invalid distro: homer\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/projects/info/bash?distro=homer\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/projects/list_test.go
+++ b/cmd/composer-cli/projects/list_test.go
@@ -6,7 +6,7 @@ package projects
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"testing"
@@ -76,7 +76,7 @@ func TestCmdProjectsList(t *testing.T) {
 		}
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -88,12 +88,12 @@ func TestCmdProjectsList(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "Name: 0ad\n")
 	assert.Contains(t, string(stdout), "Homepage: http://play0ad.com\n")
 	assert.Contains(t, string(stdout), "             open-source, cross-platform real-time")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -159,7 +159,7 @@ func TestCmdProjectsListJSON(t *testing.T) {
 		}
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -171,14 +171,14 @@ func TestCmdProjectsListJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"name\": \"0ad\"")
 	assert.Contains(t, string(stdout), "\"homepage\": \"http://play0ad.com\"")
 	assert.Contains(t, string(stdout), "\"version\": \"0.0.24b\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/projects/list?limit=0\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -244,7 +244,7 @@ func TestCmdProjectsListDistro(t *testing.T) {
 		}
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -256,12 +256,12 @@ func TestCmdProjectsListDistro(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "Name: 0ad\n")
 	assert.Contains(t, string(stdout), "Homepage: http://play0ad.com\n")
 	assert.Contains(t, string(stdout), "             open-source, cross-platform real-time")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -284,7 +284,7 @@ func TestCmdProjectsListBadDistro(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -297,10 +297,10 @@ func TestCmdProjectsListBadDistro(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "DistroError: Invalid distro: homer")
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/root/printwrap_test.go
+++ b/cmd/composer-cli/root/printwrap_test.go
@@ -5,7 +5,7 @@
 package root
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,10 +32,10 @@ func TestPrintWrapSingle(t *testing.T) {
 	defer out.Close()
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, string(stdout), "Single line test\n")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 }
@@ -46,10 +46,10 @@ func TestPrintWrapMultiple(t *testing.T) {
 	defer out.Close()
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, string(stdout), "Multi-line test,\n    with an indent\n    on the second\n    line printed\n")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 }
@@ -60,10 +60,10 @@ func TestPrintWrapWithLF(t *testing.T) {
 	defer out.Close()
 	require.NotNil(t, out.Stdout)
 	require.NotNil(t, out.Stderr)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, string(stdout), "Multi-line test,\n    with an indent\n    on the second\n    line printed\n")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 }

--- a/cmd/composer-cli/root/root_test.go
+++ b/cmd/composer-cli/root/root_test.go
@@ -6,7 +6,7 @@ package root
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -61,10 +61,10 @@ func TestOutputCapture(t *testing.T) {
 
 	err = oc.Rewind()
 	require.Nil(t, err)
-	stdout, err := ioutil.ReadAll(oc.Stdout)
+	stdout, err := io.ReadAll(oc.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "fooblitzky")
-	stderr, err := ioutil.ReadAll(oc.Stderr)
+	stderr, err := io.ReadAll(oc.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "frobozz")
 }

--- a/cmd/composer-cli/root/test_utilities.go
+++ b/cmd/composer-cli/root/test_utilities.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -39,11 +38,11 @@ type OutputCapture struct {
 // restore os.Stdout and os.Stderr
 func NewOutputCapture() (*OutputCapture, error) {
 
-	stdout, err := ioutil.TempFile("", "stdout-capture-")
+	stdout, err := os.CreateTemp("", "stdout-capture-")
 	if err != nil {
 		return nil, err
 	}
-	stderr, err := ioutil.TempFile("", "stderr-capture-")
+	stderr, err := os.CreateTemp("", "stderr-capture-")
 	if err != nil {
 		stdout.Close()
 		os.Remove(stdout.Name())

--- a/cmd/composer-cli/sources/add.go
+++ b/cmd/composer-cli/sources/add.go
@@ -5,7 +5,7 @@
 package sources
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -36,7 +36,7 @@ func init() {
 }
 
 func add(cmd *cobra.Command, args []string) error {
-	data, err := ioutil.ReadFile(args[0])
+	data, err := os.ReadFile(args[0])
 	if err != nil {
 		return root.ExecutionError(cmd, "Missing source file: %s\n", args[0])
 	}

--- a/cmd/composer-cli/sources/add_test.go
+++ b/cmd/composer-cli/sources/add_test.go
@@ -6,7 +6,7 @@ package sources
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -23,12 +23,12 @@ func TestCmdSourcesAdd(t *testing.T) {
 		json := `{"status": true}`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpSrc, err := ioutil.TempFile("", "test-src-*.toml")
+	tmpSrc, err := os.CreateTemp("", "test-src-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpSrc.Name())
 
@@ -49,15 +49,15 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, addCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
 	assert.Equal(t, "/api/v1/projects/source/new", mc.Req.URL.Path)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Contains(t, string(sentBody), "check_ssl = true")
@@ -71,12 +71,12 @@ func TestCmdSourcesAddJSON(t *testing.T) {
 		json := `{"status": true}`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpSrc, err := ioutil.TempFile("", "test-src-*.toml")
+	tmpSrc, err := os.CreateTemp("", "test-src-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpSrc.Name())
 
@@ -97,18 +97,18 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, addCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": true")
 	assert.Contains(t, string(stdout), "\"path\": \"/projects/source/new\"")
 	assert.Contains(t, string(stdout), "\"method\": \"POST\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
 	assert.Equal(t, "/api/v1/projects/source/new", mc.Req.URL.Path)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Contains(t, string(sentBody), "check_ssl = true")
@@ -132,12 +132,12 @@ func TestCmdNewSourceAddError(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpSrc, err := ioutil.TempFile("", "test-src-*.toml")
+	tmpSrc, err := os.CreateTemp("", "test-src-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpSrc.Name())
 
@@ -159,10 +159,10 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, addCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "ProjectsError")
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -185,12 +185,12 @@ func TestCmdNewSourceAddErrorJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpSrc, err := ioutil.TempFile("", "test-src-*.toml")
+	tmpSrc, err := os.CreateTemp("", "test-src-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpSrc.Name())
 
@@ -212,13 +212,13 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, addCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"ProjectsError\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"Problem parsing POST body")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -231,12 +231,12 @@ func TestCmdSourcesChange(t *testing.T) {
 		json := `{"status": true}`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpSrc, err := ioutil.TempFile("", "test-src-*.toml")
+	tmpSrc, err := os.CreateTemp("", "test-src-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpSrc.Name())
 
@@ -257,10 +257,10 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, changeCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -273,12 +273,12 @@ func TestCmdSourcesChangeJSON(t *testing.T) {
 		json := `{"status": true}`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpSrc, err := ioutil.TempFile("", "test-src-*.toml")
+	tmpSrc, err := os.CreateTemp("", "test-src-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpSrc.Name())
 
@@ -299,13 +299,13 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, changeCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": true")
 	assert.Contains(t, string(stdout), "\"path\": \"/projects/source/new\"")
 	assert.Contains(t, string(stdout), "\"method\": \"POST\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -328,12 +328,12 @@ func TestCmdNewSourceChangeError(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpSrc, err := ioutil.TempFile("", "test-src-*.toml")
+	tmpSrc, err := os.CreateTemp("", "test-src-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpSrc.Name())
 
@@ -355,10 +355,10 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, changeCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "ProjectsError")
 	assert.Equal(t, "POST", mc.Req.Method)
@@ -381,12 +381,12 @@ func TestCmdNewSourceChangeErrorJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
 	// Need a temporary test file
-	tmpSrc, err := ioutil.TempFile("", "test-src-*.toml")
+	tmpSrc, err := os.CreateTemp("", "test-src-*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpSrc.Name())
 
@@ -408,13 +408,13 @@ url = "https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=x86_64"
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, changeCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
 	assert.Contains(t, string(stdout), "\"id\": \"ProjectsError\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"Problem parsing POST body")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "POST", mc.Req.Method)

--- a/cmd/composer-cli/sources/delete_test.go
+++ b/cmd/composer-cli/sources/delete_test.go
@@ -6,7 +6,7 @@ package sources
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -23,7 +23,7 @@ func TestCmdSourcesDelete(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -35,10 +35,10 @@ func TestCmdSourcesDelete(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, deleteCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
@@ -52,7 +52,7 @@ func TestCmdSourcesDeleteJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -64,11 +64,11 @@ func TestCmdSourcesDeleteJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, deleteCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": true")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)
@@ -93,7 +93,7 @@ func TestCmdSourcesDeleteSystem(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -105,10 +105,10 @@ func TestCmdSourcesDeleteSystem(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, deleteCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "SystemSource")
 	assert.Equal(t, "DELETE", mc.Req.Method)
@@ -130,7 +130,7 @@ func TestCmdSourcesDeleteSystemJSON(t *testing.T) {
 		return &http.Response{
 			Request:    request,
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -142,7 +142,7 @@ func TestCmdSourcesDeleteSystemJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, deleteCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"status\": false")
@@ -150,7 +150,7 @@ func TestCmdSourcesDeleteSystemJSON(t *testing.T) {
 	assert.Contains(t, string(stdout), "\"msg\": \"fedora is a system source, it cannot be deleted.\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/projects/source/delete/fedora\"")
 	assert.Contains(t, string(stdout), "\"status\": 400")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "DELETE", mc.Req.Method)

--- a/cmd/composer-cli/sources/info_test.go
+++ b/cmd/composer-cli/sources/info_test.go
@@ -7,7 +7,7 @@ package sources
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -41,7 +41,7 @@ func TestCmdSourcesInfo(t *testing.T) {
 }`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -54,11 +54,11 @@ func TestCmdSourcesInfo(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "id = \"fedora\"")
 	assert.Contains(t, string(stdout), "type = \"yum-metalink\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stderr), "UnknownSource: unknown is not a valid source")
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -89,7 +89,7 @@ func TestCmdSourcesInfoJSON(t *testing.T) {
 }`
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -102,14 +102,14 @@ func TestCmdSourcesInfoJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, infoCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"id\": \"fedora\"")
 	assert.Contains(t, string(stdout), "\"type\": \"yum-metalink\"")
 	assert.Contains(t, string(stdout), "\"id\": \"UnknownSource\"")
 	assert.Contains(t, string(stdout), "\"msg\": \"unknown is not a valid source\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/sources/list_test.go
+++ b/cmd/composer-cli/sources/list_test.go
@@ -6,7 +6,7 @@ package sources
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -23,7 +23,7 @@ func TestCmdSourcesList(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -36,10 +36,10 @@ func TestCmdSourcesList(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.NotEqual(t, []byte(""), stdout)
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -52,7 +52,7 @@ func TestCmdSourcesListJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -65,13 +65,13 @@ func TestCmdSourcesListJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, listCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.True(t, root.IsJSONList(stdout))
 	assert.Contains(t, string(stdout), "\"sources\"")
 	assert.Contains(t, string(stdout), "\"fedora\"")
 	assert.Contains(t, string(stdout), "\"updates\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/cmd/composer-cli/status/show_test.go
+++ b/cmd/composer-cli/status/show_test.go
@@ -6,7 +6,7 @@ package status
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -23,7 +23,7 @@ func TestCmdStatusShow(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -35,12 +35,12 @@ func TestCmdStatusShow(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, showCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "API server status:")
 	assert.Contains(t, string(stdout), "Backend:            osbuild-composer")
 	assert.Contains(t, string(stdout), "Build:              devel")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
@@ -54,7 +54,7 @@ func TestCmdStatusShowJSON(t *testing.T) {
 
 		return &http.Response{
 			StatusCode: 200,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
 	})
 
@@ -66,12 +66,12 @@ func TestCmdStatusShowJSON(t *testing.T) {
 	require.NotNil(t, out.Stderr)
 	require.NotNil(t, cmd)
 	assert.Equal(t, cmd, showCmd)
-	stdout, err := ioutil.ReadAll(out.Stdout)
+	stdout, err := io.ReadAll(out.Stdout)
 	assert.Nil(t, err)
 	assert.Contains(t, string(stdout), "\"api\": \"1\"")
 	assert.Contains(t, string(stdout), "\"backend\": \"osbuild-composer\"")
 	assert.Contains(t, string(stdout), "\"path\": \"/api/status\"")
-	stderr, err := ioutil.ReadAll(out.Stderr)
+	stderr, err := io.ReadAll(out.Stderr)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)

--- a/weldr/apischema.go
+++ b/weldr/apischema.go
@@ -7,7 +7,7 @@ package weldr
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -64,7 +64,7 @@ func NewAPIResponse(body []byte) (*APIResponse, error) {
 func (c Client) apiError(resp *http.Response) (*APIResponse, error) {
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/weldr/common.go
+++ b/weldr/common.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -170,7 +169,7 @@ func (c Client) GetRaw(method, path string) ([]byte, *APIResponse, error) {
 	}
 	defer body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(body)
+	bodyBytes, err := io.ReadAll(body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -244,7 +243,7 @@ func (c Client) GetFile(path string) (fileName, cDisposition, cType string, apiR
 	}
 
 	// Write the body to a temporary file (caller is responsible for cleanup)
-	tmpFile, err := ioutil.TempFile("", "composer-cli-file-*")
+	tmpFile, err := os.CreateTemp("", "composer-cli-file-*")
 	if err != nil {
 		return
 	}
@@ -354,7 +353,7 @@ func (c Client) PostRaw(path, body string, headers map[string]string) ([]byte, *
 	}
 	defer resp.Body.Close()
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -392,7 +391,7 @@ func (c Client) DeleteRaw(path string) ([]byte, *APIResponse, error) {
 	}
 	defer resp.Body.Close()
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/weldr/common_test.go
+++ b/weldr/common_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -45,7 +45,7 @@ func TestRequestGetBody(t *testing.T) {
 		DoFunc: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("get body test"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("get body test"))),
 			}, nil
 		},
 	}
@@ -55,7 +55,7 @@ func TestRequestGetBody(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, r)
 	assert.Equal(t, 200, r.StatusCode)
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("get body test"), body)
@@ -79,7 +79,7 @@ func TestRequestPostBody(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, r)
 	assert.Equal(t, 200, r.StatusCode)
-	body, err := ioutil.ReadAll(mc.Req.Body)
+	body, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("post body test"), body)
@@ -119,7 +119,7 @@ func TestRequestMethods400(t *testing.T) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: 400,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("error response json"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("error response json"))),
 			}, nil
 		},
 	}
@@ -132,7 +132,7 @@ func TestRequestMethods400(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, r)
 		assert.Equal(t, 400, r.StatusCode)
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		r.Body.Close()
 		assert.Nil(t, err)
 		assert.Equal(t, []byte("error response json"), body)
@@ -163,7 +163,7 @@ func TestRequestHeaders(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, r)
 		assert.Equal(t, 200, r.StatusCode)
-		body, err := ioutil.ReadAll(mc.Req.Body)
+		body, err := io.ReadAll(mc.Req.Body)
 		mc.Req.Body.Close()
 		assert.Nil(t, err)
 		assert.Equal(t, []byte("post header test"), body)
@@ -180,7 +180,7 @@ func TestGetRawBodyMethods(t *testing.T) {
 		DoFunc: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("raw body data"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("raw body data"))),
 			}, nil
 		},
 	}
@@ -193,7 +193,7 @@ func TestGetRawBodyMethods(t *testing.T) {
 		require.Nil(t, err)
 		require.Nil(t, r)
 		require.NotNil(t, body)
-		bodyData, err := ioutil.ReadAll(body)
+		bodyData, err := io.ReadAll(body)
 		body.Close()
 		assert.Nil(t, err)
 		assert.Equal(t, []byte("raw body data"), bodyData)
@@ -210,7 +210,7 @@ func TestGetRawBodyMethods404(t *testing.T) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: 404,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -239,7 +239,7 @@ func TestGetRawBodyMethods400(t *testing.T) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: 400,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -266,7 +266,7 @@ func TestGetRaw(t *testing.T) {
 		DoFunc: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("raw body data"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("raw body data"))),
 			}, nil
 		},
 	}
@@ -293,7 +293,7 @@ func TestGetRaw404(t *testing.T) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: 404,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -322,7 +322,7 @@ func TestGetRaw400(t *testing.T) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: 400,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -355,7 +355,7 @@ func TestGetJSONAll(t *testing.T) {
 
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -377,7 +377,7 @@ func TestGetJSONAllMissingTotal(t *testing.T) {
 		DoFunc: func(request *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -395,7 +395,7 @@ func TestGetJSONAllBadJSON(t *testing.T) {
 		DoFunc: func(request *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("not really json"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("not really json"))),
 			}, nil
 		},
 	}
@@ -414,7 +414,7 @@ func TestGetJSONAllBadType(t *testing.T) {
 			json := `{"testdata": "just testing", "total": "100", "offset": 0, "limit": 20}`
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -438,7 +438,7 @@ func TestGetJSONAllFnTotal(t *testing.T) {
 
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(jsonResponse))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(jsonResponse))),
 			}, nil
 		},
 	}
@@ -475,7 +475,7 @@ func TestPostRaw(t *testing.T) {
 		DoFunc: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("raw body data"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("raw body data"))),
 			}, nil
 		},
 	}
@@ -487,7 +487,7 @@ func TestPostRaw(t *testing.T) {
 	require.NotNil(t, body)
 	assert.Equal(t, []byte("raw body data"), body)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte("post body test"), sentBody)
@@ -500,7 +500,7 @@ func TestPostRawHeaders(t *testing.T) {
 		DoFunc: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("raw body data"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("raw body data"))),
 			}, nil
 		},
 	}
@@ -518,7 +518,7 @@ func TestPostRawHeaders(t *testing.T) {
 		require.NotNil(t, body)
 		assert.Equal(t, []byte("raw body data"), body)
 		assert.Equal(t, "POST", mc.Req.Method)
-		sentBody, err := ioutil.ReadAll(mc.Req.Body)
+		sentBody, err := io.ReadAll(mc.Req.Body)
 		mc.Req.Body.Close()
 		require.Nil(t, err)
 		assert.Equal(t, []byte("post header test"), sentBody)
@@ -537,7 +537,7 @@ func TestPostRaw400(t *testing.T) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: 400,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -562,7 +562,7 @@ func TestPostRaw404(t *testing.T) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: 404,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -585,7 +585,7 @@ func TestPostTOML(t *testing.T) {
 		DoFunc: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("raw body data"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("raw body data"))),
 			}, nil
 		},
 	}
@@ -597,7 +597,7 @@ func TestPostTOML(t *testing.T) {
 	require.NotNil(t, body)
 	assert.Equal(t, []byte("raw body data"), body)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte("post header test"), sentBody)
@@ -611,7 +611,7 @@ func TestPostJSON(t *testing.T) {
 		DoFunc: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("raw body data"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("raw body data"))),
 			}, nil
 		},
 	}
@@ -623,7 +623,7 @@ func TestPostJSON(t *testing.T) {
 	require.NotNil(t, body)
 	assert.Equal(t, []byte("raw body data"), body)
 	assert.Equal(t, "POST", mc.Req.Method)
-	sentBody, err := ioutil.ReadAll(mc.Req.Body)
+	sentBody, err := io.ReadAll(mc.Req.Body)
 	mc.Req.Body.Close()
 	require.Nil(t, err)
 	assert.Equal(t, []byte("post header test"), sentBody)
@@ -637,7 +637,7 @@ func TestDeleteRaw(t *testing.T) {
 		DoFunc: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("raw body data"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("raw body data"))),
 			}, nil
 		},
 	}
@@ -660,7 +660,7 @@ func TestDeleteRaw400(t *testing.T) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: 400,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -685,7 +685,7 @@ func TestDeleteRaw404(t *testing.T) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: 404,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -708,7 +708,7 @@ func TestRawCallbackBody(t *testing.T) {
 		DoFunc: func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("raw body data"))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("raw body data"))),
 			}, nil
 		},
 	}
@@ -743,7 +743,7 @@ func TestRawCallbackResponse(t *testing.T) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: 400,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -779,7 +779,7 @@ func TestGetFile(t *testing.T) {
 
 			resp := http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("A Very Short File."))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("A Very Short File."))),
 				Header:     http.Header{},
 			}
 			resp.Header.Set("Content-Disposition", "attachment; filename=a-very-short-file.txt")
@@ -799,7 +799,7 @@ func TestGetFile(t *testing.T) {
 	assert.Equal(t, "/api/v1/file/a-very-short-file", mc.Req.URL.Path)
 	_, err = os.Stat(tf)
 	require.Nil(t, err)
-	data, _ := ioutil.ReadFile(tf)
+	data, _ := os.ReadFile(tf)
 	assert.Equal(t, []byte("A Very Short File."), data)
 	os.Remove(tf)
 }
@@ -811,7 +811,7 @@ func TestGetFileError400(t *testing.T) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: 400,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -835,7 +835,7 @@ func TestGetFilePath(t *testing.T) {
 
 			resp := http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("A Very Short File."))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("A Very Short File."))),
 				Header:     http.Header{},
 			}
 			resp.Header.Set("Content-Disposition", "attachment; filename=a-very-short-file.txt")
@@ -853,7 +853,7 @@ func TestGetFilePath(t *testing.T) {
 	assert.Equal(t, "/api/v1/file/a-very-short-file", mc.Req.URL.Path)
 	_, err = os.Stat(filename)
 	require.Nil(t, err)
-	data, _ := ioutil.ReadFile(filename)
+	data, _ := os.ReadFile(filename)
 	assert.Equal(t, []byte("A Very Short File."), data)
 
 	// Test that downloading again returns an error
@@ -870,7 +870,7 @@ func TestGetFilePathFilename(t *testing.T) {
 
 			resp := http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("A Very Short File."))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("A Very Short File."))),
 				Header:     http.Header{},
 			}
 			resp.Header.Set("Content-Disposition", "attachment; filename=a-very-short-file.txt")
@@ -888,7 +888,7 @@ func TestGetFilePathFilename(t *testing.T) {
 	assert.Equal(t, "/api/v1/file/a-very-short-file", mc.Req.URL.Path)
 	_, err = os.Stat(filename)
 	require.Nil(t, err)
-	data, _ := ioutil.ReadFile(filename)
+	data, _ := os.ReadFile(filename)
 	assert.Equal(t, []byte("A Very Short File."), data)
 
 	// Test that downloading again returns an error
@@ -905,7 +905,7 @@ func TestGetFileMissingDir(t *testing.T) {
 
 			resp := http.Response{
 				StatusCode: 200,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte("A Very Short File."))),
+				Body:       io.NopCloser(bytes.NewReader([]byte("A Very Short File."))),
 				Header:     http.Header{},
 			}
 			resp.Header.Set("Content-Disposition", "attachment; filename=a-very-short-file.txt")
@@ -934,7 +934,7 @@ func TestGetFilePathError400(t *testing.T) {
 			return &http.Response{
 				Request:    req,
 				StatusCode: 400,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte(json))),
+				Body:       io.NopCloser(bytes.NewReader([]byte(json))),
 			}, nil
 		},
 	}
@@ -1076,11 +1076,11 @@ func TestGetContentFilenameError(t *testing.T) {
 }
 
 func TestMoveFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-move-file-*")
+	dir, err := os.MkdirTemp("", "test-move-file-*")
 	require.Nil(t, err)
 	defer os.RemoveAll(dir)
 
-	f, err := ioutil.TempFile("", "test-move-file-*")
+	f, err := os.CreateTemp("", "test-move-file-*")
 	require.Nil(t, err)
 	_, err = f.Write([]byte("This is just a test file\n"))
 	require.Nil(t, err)
@@ -1110,7 +1110,7 @@ func TestCheckSocket(t *testing.T) {
 	assert.Contains(t, fmt.Sprintf("%s", err), "Check to make sure that")
 
 	// Test with existing file
-	f, err := ioutil.TempFile("", "test-CheckSocket-*")
+	f, err := os.CreateTemp("", "test-CheckSocket-*")
 	require.Nil(t, err)
 	_, err = f.Write([]byte("This is just a test file\n"))
 	require.Nil(t, err)

--- a/weldr/compose_test.go
+++ b/weldr/compose_test.go
@@ -8,7 +8,6 @@ package weldr
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -64,7 +63,7 @@ func TestStartComposeSize(t *testing.T) {
 
 func TestStartComposeUpload(t *testing.T) {
 	// Need a temporary test file
-	tmpProfile, err := ioutil.TempFile("", "test-profile-p*.toml")
+	tmpProfile, err := os.CreateTemp("", "test-profile-p*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpProfile.Name())
 
@@ -107,7 +106,7 @@ func TestStartOSTreeUrlParentError(t *testing.T) {
 
 func TestStartOSTreeComposeUpload(t *testing.T) {
 	// Need a temporary test file
-	tmpProfile, err := ioutil.TempFile("", "test-profile-p*.toml")
+	tmpProfile, err := os.CreateTemp("", "test-profile-p*.toml")
 	require.Nil(t, err)
 	defer os.Remove(tmpProfile.Name())
 

--- a/weldr/status.go
+++ b/weldr/status.go
@@ -6,7 +6,7 @@ package weldr
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 )
 
 // ServerStatus returns the status of the API server
@@ -24,7 +24,7 @@ func (c Client) ServerStatus() (StatusV0, *APIResponse, error) {
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return StatusV0{}, nil, err
 	}

--- a/weldr/utils.go
+++ b/weldr/utils.go
@@ -9,7 +9,6 @@ package weldr
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -51,7 +50,7 @@ func setUpTestState(socketPath string, unitTest bool) (*TestState, error) {
 
 // SetUpTemporaryRepository creates a temporary repository
 func SetUpTemporaryRepository() (string, error) {
-	dir, err := ioutil.TempDir("/tmp", "osbuild-composer-test-")
+	dir, err := os.MkdirTemp("/tmp", "osbuild-composer-test-")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
ioutil has been deprecated since Go 1.16, the functions have been
replaced by corresponding functions in io and os, with ioutil.TempFile
changing to os.CreateTemp, and ioutil.TempDir to os.MkdirTemp