### PR TITLE
spec: replace gourl with github url

### DIFF
--- a/weldr-client.spec.in
+++ b/weldr-client.spec.in
@@ -11,7 +11,7 @@ Release:   1%{?dist}
 # Upstream license specification: Apache-2.0
 License:   ASL 2.0
 Summary:   Command line utility to control osbuild-composer
-Url:       %{gourl}
+Url:       https://github.com/osbuild/weldr-client
 Source0:   https://github.com/osbuild/weldr-client/releases/download/v%{version}/%{name}-%{version}.tar.gz
 %if %{with signed}
 Source1:   https://github.com/osbuild/weldr-client/releases/download/v%{version}/%{name}-%{version}.tar.gz.asc


### PR DESCRIPTION
Noticed a warning when building RPMs for `weldr-client` as mentioned in #72. Seems at some point `%{gourl%}` was undefined. This sets it to a hardcoded path but perhaps we want to use `%{goipath}`?