### PR TITLE
cmdline: Add package glob support to modules list command

### DIFF
--- a/cmd/composer-cli/modules/list.go
+++ b/cmd/composer-cli/modules/list.go
@@ -10,13 +10,15 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/osbuild/weldr-client/v2/cmd/composer-cli/root"
+	"github.com/osbuild/weldr-client/v2/weldr"
 )
 
 var (
 	listCmd = &cobra.Command{
-		Use:   "list",
-		Short: "List available modules",
-		Long:  "List available modules",
+		Use:   "list [GLOB] ...",
+		Short: "List all, or search for, available modules",
+		Long:  "List all available modules, or search using glob patterns",
+		Args:  cobra.ArbitraryArgs,
 		RunE:  list,
 	}
 	distro string
@@ -28,7 +30,15 @@ func init() {
 }
 
 func list(cmd *cobra.Command, args []string) error {
-	modules, resp, err := root.Client.ListModules(distro)
+	var modules []weldr.ModuleV0
+	var resp *weldr.APIResponse
+	var err error
+
+	if len(args) > 0 {
+		modules, resp, err = root.Client.SearchModules(args, distro)
+	} else {
+		modules, resp, err = root.Client.ListModules(distro)
+	}
 	if err != nil {
 		return root.ExecutionError(cmd, "List Error: %s", err)
 	}

--- a/cmd/composer-cli/modules/list_test.go
+++ b/cmd/composer-cli/modules/list_test.go
@@ -270,3 +270,456 @@ func TestCmdModulesListBadDistroJSON(t *testing.T) {
 	assert.Equal(t, []byte(""), stderr)
 	assert.Equal(t, "GET", mc.Req.Method)
 }
+
+func TestCmdModulesSearch(t *testing.T) {
+	// Test the "modules list [GLOB] ..." command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		var json string
+		if limit == 0 {
+			json = `{"modules": [], "total": 1, "offset": 0, "limit": 0}`
+		} else {
+			json = `{"modules": [{"name":"tmux", "group_type":"rpm"}],
+					"total": 1, "offset": 0, "limit": 1}`
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("modules", "list", "tmux")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := io.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "tmux")
+	stderr, err := io.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/list/tmux", mc.Req.URL.Path)
+}
+
+func TestCmdModulesSearchTwo(t *testing.T) {
+	// Test the "modules list [GLOB] ..." command with 2 packages
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		var json string
+		if limit == 0 {
+			json = `{"modules": [], "total": 2, "offset": 0, "limit": 0}`
+		} else {
+			json = `{"modules": [
+						{"name":"tmux", "group_type":"rpm"},
+						{"name":"zsh", "group_type":"rpm"}],
+					"total": 2, "offset": 0, "limit": 2}`
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("modules", "list", "tmux", "zsh")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := io.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "tmux")
+	assert.Contains(t, string(stdout), "zsh")
+	stderr, err := io.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/list/tmux,zsh", mc.Req.URL.Path)
+}
+
+func TestCmdModulesSearchJSON(t *testing.T) {
+	// Test the "modules list [GLOB] ..." command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		var json string
+		if limit == 0 {
+			json = `{"modules": [], "total": 1, "offset": 0, "limit": 0}`
+		} else {
+			json = `{"modules": [{"name":"tmux", "group_type":"rpm"}],
+					"total": 1, "offset": 0, "limit": 1}`
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "modules", "list", "tmux")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := io.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.True(t, root.IsJSONList(stdout))
+	assert.Contains(t, string(stdout), "\"name\": \"tmux\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/modules/list/tmux?limit=0\"")
+	stderr, err := io.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/list/tmux", mc.Req.URL.Path)
+}
+
+func TestCmdModulesSearchTwoJSON(t *testing.T) {
+	// Test the "modules list [GLOB] ..." command with two packages
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		var json string
+		if limit == 0 {
+			json = `{"modules": [], "total": 2, "offset": 0, "limit": 0}`
+		} else {
+			json = `{"modules": [
+						{"name":"tmux", "group_type":"rpm"},
+						{"name":"zsh", "group_type":"rpm"}],
+					"total": 2, "offset": 0, "limit": 2}`
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "modules", "list", "tmux", "zsh")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := io.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.True(t, root.IsJSONList(stdout))
+	assert.Contains(t, string(stdout), "\"name\": \"tmux\"")
+	assert.Contains(t, string(stdout), "\"name\": \"zsh\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/modules/list/tmux,zsh?limit=0\"")
+	stderr, err := io.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/list/tmux,zsh", mc.Req.URL.Path)
+}
+
+func TestCmdModulesSearchDistro(t *testing.T) {
+	// Test the "modules list --distro=test-distro [GLOB] ..." command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		var json string
+		if limit == 0 {
+			json = `{"modules": [], "total": 1, "offset": 0, "limit": 0}`
+		} else {
+			json = `{"modules": [{"name":"tmux", "group_type":"rpm"}],
+					"total": 1, "offset": 0, "limit": 1}`
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("modules", "list", "--distro=test-distro", "tmux")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := io.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "tmux")
+	stderr, err := io.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/list/tmux", mc.Req.URL.Path)
+}
+
+func TestCmdModulesSearchDistroTwo(t *testing.T) {
+	// Test the "modules list --distro=test-distro [GLOB] ..." command with two packages
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		var json string
+		if limit == 0 {
+			json = `{"modules": [], "total": 2, "offset": 0, "limit": 0}`
+		} else {
+			json = `{"modules": [
+						{"name":"tmux", "group_type":"rpm"},
+						{"name":"zsh", "group_type":"rpm"}],
+					"total": 2, "offset": 0, "limit": 2}`
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("modules", "list", "--distro=test-distro", "tmux", "zsh")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := io.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stdout), "tmux")
+	assert.Contains(t, string(stdout), "zsh")
+	stderr, err := io.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/list/tmux,zsh", mc.Req.URL.Path)
+}
+
+func TestCmdModulesSearchDistroJSON(t *testing.T) {
+	// Test the "modules list --distro=test-distro [GLOB] ..." command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		var json string
+		if limit == 0 {
+			json = `{"modules": [], "total": 1, "offset": 0, "limit": 0}`
+		} else {
+			json = `{"modules": [{"name":"tmux", "group_type":"rpm"}],
+					"total": 1, "offset": 0, "limit": 1}`
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "modules", "list", "--distro=test-distro", "tmux")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := io.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.True(t, root.IsJSONList(stdout))
+	assert.Contains(t, string(stdout), "\"name\": \"tmux\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/modules/list/tmux?distro=test-distro\\u0026limit=0\"")
+	stderr, err := io.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/list/tmux", mc.Req.URL.Path)
+}
+
+func TestCmdModulesSearchDistroTwoJSON(t *testing.T) {
+	// Test the "modules list --distro=test-distro [GLOB] ..." command with two packages
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		query := request.URL.Query()
+		v := query.Get("limit")
+		limit, _ := strconv.ParseUint(v, 10, 64)
+		var json string
+		if limit == 0 {
+			json = `{"modules": [], "total": 2, "offset": 0, "limit": 0}`
+		} else {
+			json = `{"modules": [
+						{"name":"tmux", "group_type":"rpm"},
+						{"name":"zsh", "group_type":"rpm"}],
+					"total": 2, "offset": 0, "limit": 2}`
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "modules", "list", "--distro=test-distro", "tmux", "zsh")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.Nil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := io.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.True(t, root.IsJSONList(stdout))
+	assert.Contains(t, string(stdout), "\"name\": \"tmux\"")
+	assert.Contains(t, string(stdout), "\"name\": \"zsh\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/modules/list/tmux,zsh?distro=test-distro\\u0026limit=0\"")
+	stderr, err := io.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+	assert.Equal(t, "/api/v1/modules/list/tmux,zsh", mc.Req.URL.Path)
+}
+
+func TestCmdModulesSearchBadModule(t *testing.T) {
+	// Test the "modules list [GLOB] ..." command with an unknown module
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+        "errors": [
+            {
+                "id": "UnknownModule",
+                "msg": "No packages have been found."
+            }
+        ],
+        "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get the compose types
+	distro = ""
+	cmd, out, err := root.ExecuteTest("modules", "list", "foobar")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := io.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stdout)
+	stderr, err := io.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stderr), "UnknownModule: No packages have been found.")
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdModulesSearchBadDistro(t *testing.T) {
+	// Test the "modules list --distro=homer [GLOB] ..." command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+        "errors": [
+            {
+                "id": "DistroError",
+                "msg": "Invalid distro: homer"
+            }
+        ],
+        "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get the compose types
+	distro = ""
+	cmd, out, err := root.ExecuteTest("modules", "list", "--distro=homer", "tmux")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := io.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stdout)
+	stderr, err := io.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Contains(t, string(stderr), "DistroError: Invalid distro: homer")
+	assert.Equal(t, "GET", mc.Req.Method)
+}
+
+func TestCmdModulesSearchBadDistroJSON(t *testing.T) {
+	// Test the "modules list --distro=homer" command
+	mc := root.SetupCmdTest(func(request *http.Request) (*http.Response, error) {
+		json := `{
+        "errors": [
+            {
+                "id": "DistroError",
+                "msg": "Invalid distro: homer"
+            }
+        ],
+        "status": false
+}`
+
+		return &http.Response{
+			Request:    request,
+			StatusCode: 400,
+			Body:       io.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	})
+
+	// Get the compose types
+	distro = ""
+	cmd, out, err := root.ExecuteTest("--json", "modules", "list", "--distro=homer", "tmux")
+	require.NotNil(t, out)
+	defer out.Close()
+	require.NotNil(t, err)
+	require.NotNil(t, out.Stdout)
+	require.NotNil(t, out.Stderr)
+	require.NotNil(t, cmd)
+	assert.Equal(t, cmd, listCmd)
+	stdout, err := io.ReadAll(out.Stdout)
+	assert.Nil(t, err)
+	assert.True(t, root.IsJSONList(stdout))
+	assert.Contains(t, string(stdout), "\"status\": false")
+	assert.Contains(t, string(stdout), "\"id\": \"DistroError\"")
+	assert.Contains(t, string(stdout), "\"msg\": \"Invalid distro: homer\"")
+	assert.Contains(t, string(stdout), "\"path\": \"/api/v1/modules/list/tmux?distro=homer\\u0026limit=0\"")
+	stderr, err := io.ReadAll(out.Stderr)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte(""), stderr)
+	assert.Equal(t, "GET", mc.Req.Method)
+}

--- a/weldr/modules.go
+++ b/weldr/modules.go
@@ -32,6 +32,26 @@ func (c Client) ListModules(distro string) ([]ModuleV0, *APIResponse, error) {
 	return list.Modules, nil, nil
 }
 
+// SearchModules returns a list of all of the modules matching all of the globs
+// NOTE: These are just packages, the server does not support modules directly
+func (c Client) SearchModules(names []string, distro string) ([]ModuleV0, *APIResponse, error) {
+	route := fmt.Sprintf("/modules/list/%s", strings.Join(names, ","))
+	if len(distro) > 0 {
+		route = fmt.Sprintf("%s?distro=%s", route, distro)
+	}
+
+	body, resp, err := c.GetJSONAll(route)
+	if resp != nil || err != nil {
+		return nil, resp, err
+	}
+	var list ModulesListV0
+	err = json.Unmarshal(body, &list)
+	if err != nil {
+		return nil, nil, err
+	}
+	return list.Modules, nil, nil
+}
+
 // ModulesInfo returns a list of detailed info about the modules, including deps
 func (c Client) ModulesInfo(names []string, distro string) ([]ProjectV0, *APIResponse, error) {
 	route := fmt.Sprintf("/modules/info/%s", strings.Join(names, ","))

--- a/weldr/modules_test.go
+++ b/weldr/modules_test.go
@@ -2,6 +2,7 @@
 // Use of this source is goverend by the Apache License
 // that can be found in the LICENSE file.
 
+//go:build integration
 // +build integration
 
 package weldr
@@ -28,6 +29,26 @@ func TestListModulesDistro(t *testing.T) {
 	require.Nil(t, r)
 	require.NotNil(t, modules)
 	assert.GreaterOrEqual(t, len(modules), 2)
+	assert.Equal(t, "rpm", modules[0].Type)
+}
+
+func TestSearchModules(t *testing.T) {
+	modules, r, err := testState.client.SearchModules([]string{"tmux"}, "")
+	require.Nil(t, err)
+	require.Nil(t, r)
+	require.NotNil(t, modules)
+	assert.GreaterOrEqual(t, len(modules), 1)
+	assert.Equal(t, "tmux", modules[0].Name)
+	assert.Equal(t, "rpm", modules[0].Type)
+}
+
+func TestSearchModulesDistro(t *testing.T) {
+	modules, r, err := testState.client.SearchModules([]string{"tmux"}, testState.distros[0])
+	require.Nil(t, err)
+	require.Nil(t, r)
+	require.NotNil(t, modules)
+	assert.GreaterOrEqual(t, len(modules), 1)
+	assert.Equal(t, "tmux", modules[0].Name)
 	assert.Equal(t, "rpm", modules[0].Type)
 }
 


### PR DESCRIPTION
The API supports searching for packages using '*' globs. This adds support for using that via 'composer-cli modules list foo bar* baz' to search for packages matching the exact name or wildcard.

This includes both unit tests for the cmdline and integration tests for the weldr client library which has a new SearchModules function to support this.