### PR TITLE
Build weldr-client-tests by default

### DIFF
--- a/weldr-client.spec.in
+++ b/weldr-client.spec.in
@@ -1,5 +1,5 @@
-# Pass --with tests to rpmbuild to build composer-cli-tests
-%bcond_with tests
+# Pass --without tests to skip building composer-cli-tests
+%bcond_without tests
 # Pass --without signed to skip gpg signed tar.gz (DO NOT DO THAT IN PRODUCTION)
 %bcond_without signed
 


### PR DESCRIPTION
Added tmt tests to Fedora, and they depend on weldr-client-tests so switch the flag. If you do not want to build the integration tests, pass --without tests to rpmbuild.