### PR TITLE
spec: migrate the license field to SPDX

### DIFF
--- a/weldr-client.spec.in
+++ b/weldr-client.spec.in
@@ -9,7 +9,7 @@ Name:      weldr-client
 Version:   %%VERSION%%
 Release:   1%{?dist}
 # Upstream license specification: Apache-2.0
-License:   ASL 2.0
+License:   Apache-2.0
 Summary:   Command line utility to control osbuild-composer
 
 %gometa


### PR DESCRIPTION
See the relevant Fedora change:
https://fedoraproject.org/wiki/Changes/SPDX_Licenses_Phase_1

We already verified that the SPDX format works well in the Enterprise Linux pipeline.