### PR TITLE
Display warnings thrown when creating a new compose

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -2,7 +2,7 @@
 
 This new implementation of composer-cli is broken up into 2 major pieces. The
 `./weldr/` package contains the library functions for communicating with the
-API server. These functions are publicly accessable and should be documented so
+API server. These functions are publicly accessible and should be documented so
 that 3rd party users can use them to communicate with the osbuild-composer
 server.
 
@@ -103,7 +103,7 @@ See `cmd/composer-cli/blueprints/list.go` for an example of this type of handlin
 
 If there could be more than one error, eg. when processing a list of
 blueprints, the command function should print them to `os.Stderr` as `ERROR: ...\n`
-and return a blank root.ExecutionError(cmd, "")` to the root handler. See
+and return a blank `root.ExecutionError(cmd, "")` to the root handler. See
 `cmd/composer-cli/blueprints/push.go` for an example.
 
 

--- a/cmd/composer-cli/compose/start.go
+++ b/cmd/composer-cli/compose/start.go
@@ -42,12 +42,12 @@ func start(cmd *cobra.Command, args []string) error {
 	var resp *weldr.APIResponse
 	var uuid string
 	var err error
+	var warnings []string
 	// 2 args is uploads
 	if len(args) == 2 {
-		uuid, resp, err = root.Client.StartCompose(args[0], args[1], size)
+		uuid, warnings, resp, err = root.Client.StartCompose(args[0], args[1], size)
 	} else if len(args) == 4 {
-		uuid, resp, err = root.Client.StartComposeUpload(args[0], args[1], args[2], args[3], size)
-
+		uuid, warnings, resp, err = root.Client.StartComposeUpload(args[0], args[1], args[2], args[3], size)
 	}
 	if err != nil {
 		return root.ExecutionError(cmd, "Push TOML Error: %s", err)
@@ -55,7 +55,12 @@ func start(cmd *cobra.Command, args []string) error {
 	if resp != nil && !resp.Status {
 		return root.ExecutionErrors(cmd, resp.Errors)
 	}
-
+	if len(warnings) > 0 {
+		for _, w := range warnings {
+			fmt.Printf("WARNING: %s", w)
+		}
+		fmt.Printf("\n")
+	}
 	fmt.Printf("Compose %s added to the queue\n", uuid)
 	return nil
 }

--- a/cmd/composer-cli/compose/start_ostree.go
+++ b/cmd/composer-cli/compose/start_ostree.go
@@ -56,11 +56,12 @@ func startOSTree(cmd *cobra.Command, args []string) error {
 	var resp *weldr.APIResponse
 	var uuid string
 	var err error
+	var warnings []string
 	// 2 args is uploads
 	if len(args) == 2 {
-		uuid, resp, err = root.Client.StartOSTreeCompose(args[0], args[1], ref, parent, url, size)
+		uuid, warnings, resp, err = root.Client.StartOSTreeCompose(args[0], args[1], ref, parent, url, size)
 	} else if len(args) == 4 {
-		uuid, resp, err = root.Client.StartOSTreeComposeUpload(args[0], args[1], args[2], args[3], ref, parent, url, size)
+		uuid, warnings, resp, err = root.Client.StartOSTreeComposeUpload(args[0], args[1], args[2], args[3], ref, parent, url, size)
 
 	}
 	if err != nil {
@@ -70,6 +71,12 @@ func startOSTree(cmd *cobra.Command, args []string) error {
 		return root.ExecutionErrors(cmd, resp.Errors)
 	}
 
+	if len(warnings) > 0 {
+		for _, w := range warnings {
+			fmt.Printf("WARNING: %s", w)
+		}
+		fmt.Printf("\n")
+	}
 	fmt.Printf("Compose %s added to the queue\n", uuid)
 	return nil
 }

--- a/weldr/apischema.go
+++ b/weldr/apischema.go
@@ -66,7 +66,8 @@ func NewAPIResponse(body []byte) (*APIResponse, error) {
 // apiError converts an API error 400 JSON to a status response
 //
 // The response body should alway be of the form:
-//     {"status": false, "errors": [{"id": ERROR_ID, "msg": ERROR_MESSAGE}, ...]}
+//
+//	{"status": false, "errors": [{"id": ERROR_ID, "msg": ERROR_MESSAGE}, ...]}
 func (c Client) apiError(resp *http.Response) (*APIResponse, error) {
 	defer resp.Body.Close()
 
@@ -167,8 +168,9 @@ type ComposeTypesV0 struct {
 
 // ComposeStartV0 is the response to a successful start compose
 type ComposeStartV0 struct {
-	ID     string `json:"build_id"`
-	Status bool   `json:"status"`
+	ID       string   `json:"build_id"`
+	Status   bool     `json:"status"`
+	Warnings []string `json:"warnings"`
 }
 
 // ComposeDeleteV0 is the response to a delete request

--- a/weldr/compose_test.go
+++ b/weldr/compose_test.go
@@ -49,14 +49,14 @@ func TestGetComposeTypesDistro(t *testing.T) {
 }
 
 func TestStartCompose(t *testing.T) {
-	id, r, err := testState.client.StartComposeTest("cli-test-bp-1", "qcow2", 0, 2)
+	id, _, r, err := testState.client.StartComposeTest("cli-test-bp-1", "qcow2", 0, 2)
 	require.Nil(t, err)
 	require.Nil(t, r)
 	assert.Greater(t, len(id), 0)
 }
 
 func TestStartComposeSize(t *testing.T) {
-	id, r, err := testState.client.StartComposeTest("cli-test-bp-1", "qcow2", 998, 2)
+	id, _, r, err := testState.client.StartComposeTest("cli-test-bp-1", "qcow2", 998, 2)
 	require.Nil(t, err)
 	require.Nil(t, r)
 	assert.Greater(t, len(id), 0)
@@ -77,21 +77,21 @@ aws_secret_key = "AWS Secret Key"
 `))
 	require.Nil(t, err)
 
-	id, r, err := testState.client.StartComposeTestUpload("cli-test-bp-1", "qcow2", "test-image", tmpProfile.Name(), 0, 2)
+	id, _, r, err := testState.client.StartComposeTestUpload("cli-test-bp-1", "qcow2", "test-image", tmpProfile.Name(), 0, 2)
 	require.Nil(t, err)
 	require.Nil(t, r)
 	assert.Greater(t, len(id), 0)
 }
 
 func TestStartOSTreeCompose(t *testing.T) {
-	id, r, err := testState.client.StartOSTreeComposeTest("cli-test-bp-1", "qcow2", "refid", "parent", "", 0, 2)
+	id, _, r, err := testState.client.StartOSTreeComposeTest("cli-test-bp-1", "qcow2", "refid", "parent", "", 0, 2)
 	require.Nil(t, err)
 	require.Nil(t, r)
 	assert.Greater(t, len(id), 0)
 }
 
 func TestStartOSTreeComposeUrl(t *testing.T) {
-	id, r, err := testState.client.StartOSTreeComposeTest("cli-test-bp-1", "qcow2", "refid", "", "http://weldr.io", 0, 2)
+	id, _, r, err := testState.client.StartOSTreeComposeTest("cli-test-bp-1", "qcow2", "refid", "", "http://weldr.io", 0, 2)
 	require.Nil(t, err)
 	require.Nil(t, r)
 	assert.Greater(t, len(id), 0)
@@ -99,7 +99,7 @@ func TestStartOSTreeComposeUrl(t *testing.T) {
 
 func TestStartOSTreeUrlParentError(t *testing.T) {
 	// Sending both the parent url and the parent id is now allowed
-	id, r, err := testState.client.StartOSTreeComposeTest("cli-test-bp-1", "qcow2", "refid", "parent", "http://weldr.io", 0, 2)
+	id, _, r, err := testState.client.StartOSTreeComposeTest("cli-test-bp-1", "qcow2", "refid", "parent", "http://weldr.io", 0, 2)
 	require.Nil(t, err)
 	require.Nil(t, r)
 	assert.Greater(t, len(id), 0)
@@ -120,14 +120,14 @@ aws_secret_key = "AWS Secret Key"
 `))
 	require.Nil(t, err)
 
-	id, r, err := testState.client.StartOSTreeComposeTestUpload("cli-test-bp-1", "qcow2", "test-image", tmpProfile.Name(), "refid", "", "http://weldr.io", 0, 2)
+	id, _, r, err := testState.client.StartOSTreeComposeTestUpload("cli-test-bp-1", "qcow2", "test-image", tmpProfile.Name(), "refid", "", "http://weldr.io", 0, 2)
 	require.Nil(t, err)
 	require.Nil(t, r)
 	assert.Greater(t, len(id), 0)
 }
 
 func TestStartComposeUnknownBlueprint(t *testing.T) {
-	_, r, err := testState.client.StartCompose("thingy", "qcow2", 0)
+	_, _, r, err := testState.client.StartCompose("thingy", "qcow2", 0)
 	require.Nil(t, err)
 	require.NotNil(t, r)
 	assert.False(t, r.Status)
@@ -135,7 +135,7 @@ func TestStartComposeUnknownBlueprint(t *testing.T) {
 }
 
 func TestStartComposeBadType(t *testing.T) {
-	_, r, err := testState.client.StartCompose("cli-test-bp-1", "punchcard", 0)
+	_, _, r, err := testState.client.StartCompose("cli-test-bp-1", "punchcard", 0)
 	require.Nil(t, err)
 	require.NotNil(t, r)
 	assert.False(t, r.Status)
@@ -143,7 +143,7 @@ func TestStartComposeBadType(t *testing.T) {
 }
 
 func TestStartComposeBadDepsolve(t *testing.T) {
-	id, r, err := testState.client.StartCompose("cli-test-bp-3", "qcow2", 0)
+	id, _, r, err := testState.client.StartCompose("cli-test-bp-3", "qcow2", 0)
 	require.Nil(t, err)
 	require.NotNil(t, r)
 	assert.Equal(t, 0, len(id))
@@ -153,7 +153,7 @@ func TestStartComposeBadDepsolve(t *testing.T) {
 }
 
 func TestDeleteComposes(t *testing.T) {
-	id, rs, err := testState.client.StartComposeTest("cli-test-bp-1", "qcow2", 0, 2)
+	id, _, rs, err := testState.client.StartComposeTest("cli-test-bp-1", "qcow2", 0, 2)
 	require.Nil(t, err)
 	require.Nil(t, rs)
 	assert.Greater(t, len(id), 0)
@@ -167,7 +167,7 @@ func TestDeleteComposes(t *testing.T) {
 }
 
 func TestDeleteComposesMultiple(t *testing.T) {
-	id, rs, err := testState.client.StartComposeTest("cli-test-bp-1", "qcow2", 0, 2)
+	id, _, rs, err := testState.client.StartComposeTest("cli-test-bp-1", "qcow2", 0, 2)
 	require.Nil(t, err)
 	require.Nil(t, rs)
 	assert.Greater(t, len(id), 0)
@@ -183,7 +183,7 @@ func TestDeleteComposesMultiple(t *testing.T) {
 }
 
 func TestCancelFinishedCompose(t *testing.T) {
-	id, rs, err := testState.client.StartComposeTest("cli-test-bp-1", "qcow2", 0, 2)
+	id, _, rs, err := testState.client.StartComposeTest("cli-test-bp-1", "qcow2", 0, 2)
 	require.Nil(t, err)
 	require.Nil(t, rs)
 	assert.Greater(t, len(id), 0)
@@ -220,7 +220,7 @@ func TestComposeLogUnknown(t *testing.T) {
 
 func MakeFinishedCompose(t *testing.T) string {
 	// We need a finished compose to download from
-	id, r, err := testState.client.StartComposeTest("cli-test-bp-1", "qcow2", 0, 2)
+	id, _, r, err := testState.client.StartComposeTest("cli-test-bp-1", "qcow2", 0, 2)
 	require.Nil(t, err)
 	require.Nil(t, r)
 	require.Greater(t, len(id), 0)

--- a/weldr/integration_test.go
+++ b/weldr/integration_test.go
@@ -149,7 +149,7 @@ func executeTests(m *testing.M) int {
 
 	// Create some fake successful composes
 	for _, bp := range []string{"cli-test-bp-1", "cli-test-bp-2"} {
-		_, resp, err := testState.client.StartComposeTest(bp, "qcow2", 0, 2)
+		_, _, resp, err := testState.client.StartComposeTest(bp, "qcow2", 0, 2)
 		if err != nil {
 			panic(err)
 		}
@@ -160,7 +160,7 @@ func executeTests(m *testing.M) int {
 
 	// Create some fake failed composes
 	for _, bp := range []string{"cli-test-bp-1", "cli-test-bp-2"} {
-		_, resp, err := testState.client.StartComposeTest(bp, "qcow2", 0, 1)
+		_, _, resp, err := testState.client.StartComposeTest(bp, "qcow2", 0, 1)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This handles the new field `warnings` returned by osbuild-composer
when a new compose is started. These warnings are printed so that
the user can become aware of them.

This works along with https://github.com/osbuild/osbuild-composer/pull/3319.
