### PR TITLE
workflow: Ignore govulncheck failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,9 @@ jobs:
         if: matrix.go == 18
         run: bash <(curl -s https://codecov.io/bash)
 
+# This always fails because we need to use go 1.18.x and some
+# vulnerabilities aren't fixed until 1.19 or 1.20
+# so we continue running it, but it doesn't count against the PR.
   govulncheck:
     runs-on: ubuntu-latest
     steps:
@@ -64,6 +67,7 @@ jobs:
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck
+        continue-on-error: true
         run: govulncheck ./...
 
   build-test:


### PR DESCRIPTION
We need to test with go 1.18.x and some of the vulnerabilities found aren't fixed until v1.19 or v1.20, so continue running the test but don't let failures count against the PR.