### PR TITLE
Add support for compose start warning messages

### DIFF
--- a/cmd/composer-cli/compose/start.go
+++ b/cmd/composer-cli/compose/start.go
@@ -47,13 +47,18 @@ func start(cmd *cobra.Command, args []string) error {
 		uuid, resp, err = root.Client.StartCompose(args[0], args[1], size)
 	} else if len(args) == 4 {
 		uuid, resp, err = root.Client.StartComposeUpload(args[0], args[1], args[2], args[3], size)
-
 	}
 	if err != nil {
 		return root.ExecutionError(cmd, "Push TOML Error: %s", err)
 	}
-	if resp != nil && !resp.Status {
-		return root.ExecutionErrors(cmd, resp.Errors)
+	if resp != nil {
+		// Response may be just warnings, just error, or both.
+		for _, w := range resp.Warnings {
+			fmt.Printf("Warning: %s\n", w)
+		}
+		if !resp.Status {
+			return root.ExecutionErrors(cmd, resp.Errors)
+		}
 	}
 
 	fmt.Printf("Compose %s added to the queue\n", uuid)

--- a/cmd/composer-cli/compose/start_ostree.go
+++ b/cmd/composer-cli/compose/start_ostree.go
@@ -61,13 +61,18 @@ func startOSTree(cmd *cobra.Command, args []string) error {
 		uuid, resp, err = root.Client.StartOSTreeCompose(args[0], args[1], ref, parent, url, size)
 	} else if len(args) == 4 {
 		uuid, resp, err = root.Client.StartOSTreeComposeUpload(args[0], args[1], args[2], args[3], ref, parent, url, size)
-
 	}
 	if err != nil {
 		return root.ExecutionError(cmd, "Problem starting OSTree compose: %s", err)
 	}
-	if resp != nil && !resp.Status {
-		return root.ExecutionErrors(cmd, resp.Errors)
+	if resp != nil {
+		// Response may be just warnings, just error, or both.
+		for _, w := range resp.Warnings {
+			fmt.Printf("Warning: %s\n", w)
+		}
+		if !resp.Status {
+			return root.ExecutionErrors(cmd, resp.Errors)
+		}
 	}
 
 	fmt.Printf("Compose %s added to the queue\n", uuid)

--- a/weldr/apischema.go
+++ b/weldr/apischema.go
@@ -29,6 +29,7 @@ func (r APIErrorMsg) String() string {
 type APIResponse struct {
 	Status     bool          `json:"status"`
 	Errors     []APIErrorMsg `json:"errors,omitempty"`
+	Warnings   []string      // Optional warning string
 	statusCode int           // http status code
 }
 
@@ -38,6 +39,11 @@ func (r APIResponse) String() string {
 		return ""
 	}
 	return r.Errors[0].String()
+}
+
+// IsWarning returns true if is is just warnings
+func (r APIResponse) IsWarning() bool {
+	return r.Status && bool(len(r.Warnings) > 0)
 }
 
 // AllErrors returns a list of error description strings
@@ -167,8 +173,9 @@ type ComposeTypesV0 struct {
 
 // ComposeStartV0 is the response to a successful start compose
 type ComposeStartV0 struct {
-	ID     string `json:"build_id"`
-	Status bool   `json:"status"`
+	ID       string   `json:"build_id"`
+	Status   bool     `json:"status"`
+	Warnings []string `json:"warnings"`
 }
 
 // ComposeDeleteV0 is the response to a delete request

--- a/weldr/compose.go
+++ b/weldr/compose.go
@@ -269,8 +269,12 @@ func (c Client) startComposeTest(request interface{}, test uint) (string, *APIRe
 	if err != nil {
 		return "", nil, err
 	}
+	if len(build.Warnings) > 0 {
+		// Make an API response with the warnings
+		resp = &APIResponse{Status: build.Status, Warnings: build.Warnings}
+	}
 
-	return build.ID, resp, err
+	return build.ID, resp, nil
 }
 
 // DeleteComposes removes a list of composes from the server


### PR DESCRIPTION
osbuild-composer v79 can include a list of warning strings in the compose start result structure. This commit adds support for that to weldr/compose.go and to composer-cli which will print 'Warning: <string>' for each of them before printing the new compose UUID.

ComposeStartV0 has been changed to add a Warnings list of strings. Since this is an addition I didn't bump the API version. Callers should be testing the response Status flag to determine if the request was successful. It may now also contain Warnings when the flag is true.

The startCompose functions can return an APIResponse that includes the Warnings while also returning the UUID. In the future it may be possible to return errors and warnings, so the APIResponse Status flag should continue to be used to determine if the response is an error (Status == false).