### PR TITLE
composer-cli: Update doc links

### DIFF
--- a/cmd/composer-cli/blueprints/blueprints.go
+++ b/cmd/composer-cli/blueprints/blueprints.go
@@ -17,7 +17,7 @@ var (
 		Long: `Manage blueprints on the server
 
   The full blueprint reference can be found here:
-  https://www.osbuild.org/guides/blueprint-reference/blueprint-reference.html
+  https://www.osbuild.org/guides/image-builder-on-premises/blueprint-reference.html
 `,
 		Example: `  TOML blueprint for an image with tmux, a user, and a new group for the user:
 

--- a/cmd/composer-cli/compose/compose.go
+++ b/cmd/composer-cli/compose/compose.go
@@ -18,7 +18,7 @@ var (
 
   The 'start' and 'start-ostree' commands can optionally upload the results,
   view the full upload profile reference here:
-  https://www.osbuild.org/guides/user-guide/uploading-to-cloud.html
+  https://www.osbuild.org/guides/image-builder-on-premises/uploading-to-cloud.html
 `,
 		Example: `  TOML profile for uploading to AWS
 

--- a/cmd/composer-cli/compose/start_ostree.go
+++ b/cmd/composer-cli/compose/start_ostree.go
@@ -23,7 +23,7 @@ var (
   --size is supported by osbuild-composer, and is in MiB.
 
   The full details of the start-ostree command can be viewed here:
-  https://www.osbuild.org/guides/user-guide/building-ostree-images.html
+  https://www.osbuild.org/guides/image-builder-on-premises/building-ostree-images.html
 `,
 		Example: `  composer-cli compose start-ostree tmux-image fedora-iot-container
   composer-cli compose start-ostree tmux-image fedora-iot-container iot-name upload.toml

--- a/cmd/composer-cli/sources/sources.go
+++ b/cmd/composer-cli/sources/sources.go
@@ -17,7 +17,7 @@ var (
 		Long: `Manage project sources on the server
 
   The full source reference can be found here:
-  https://www.osbuild.org/guides/user-guide/managing-repositories.html
+  https://www.osbuild.org/guides/image-builder-on-premises/managing-repositories.html
 `,
 		Example: `  TOML source for 3rd party rpm repository without gpg checking
 


### PR DESCRIPTION
The osbuild.org/guides page was restructured, so the links to it need to be updated to not result in 404s.