### PR TITLE
info: Add upload status to the output

### DIFF
--- a/cmd/composer-cli/compose/info.go
+++ b/cmd/composer-cli/compose/info.go
@@ -47,6 +47,17 @@ func info(cmd *cobra.Command, args []string) error {
 		info.ComposeType,
 		imageSize)
 
+	if len(info.Uploads) > 0 {
+		fmt.Printf("Uploads:\n")
+		for i := range info.Uploads {
+			fmt.Printf("    %s %-8s %-15s %s\n",
+				info.Uploads[i].UUID,
+				info.Uploads[i].Status,
+				info.Uploads[i].Name,
+				info.Uploads[i].Provider)
+		}
+	}
+
 	fmt.Println("Packages:")
 	for _, p := range info.Blueprint.Packages {
 		fmt.Printf("    %s\n", p)

--- a/weldr/apischema.go
+++ b/weldr/apischema.go
@@ -221,6 +221,14 @@ type Group struct {
 	Name string `json:"name" toml:"name"`
 }
 
+// infoBlueprint contains the parts of the upload status useful for the compose info command
+type infoUpload struct {
+	Name     string `json:"image_name"`
+	Provider string `json:"provider_name"`
+	Status   string `json:"status"`
+	UUID     string `json:"uuid"`
+}
+
 // ComposeInfoV0 is the response to a compose/info request
 type ComposeInfoV0 struct {
 	ID        string        `json:"id"`
@@ -230,9 +238,10 @@ type ComposeInfoV0 struct {
 	Deps      struct {
 		Packages []PackageNEVRA `json:"packages"`
 	} `json:"deps"`
-	ComposeType string `json:"compose_type"`
-	QueueStatus string `json:"queue_status"`
-	ImageSize   uint64 `json:"image_size"`
+	ComposeType string       `json:"compose_type"`
+	QueueStatus string       `json:"queue_status"`
+	ImageSize   uint64       `json:"image_size"`
+	Uploads     []infoUpload `json:"uploads"` // upload parts that info cares about
 }
 
 // ModulesListV0 is the response to /modules/list request


### PR DESCRIPTION
When an upload has been requested the info status contains details about the upload and whether or not it was successful. This adds a new section, 'Uploads' which lists the UUID, status, image name, and provider name.