### PR TITLE
go.mod: Use go 1.20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 19
           - 20
           - 21
           - 22
@@ -35,7 +34,6 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 19
           - 20
           - 21
           - 22
@@ -60,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/weldr-client/v2
 
-go 1.19
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION=1.19.11
+GO_VERSION=1.20.12
 GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 
 # this is the official way to get a different version of golang


### PR DESCRIPTION
We no longer need to support 1.19, switch to 1.20 and updated the github workflow and prepare-source.sh script.