### PR TITLE
workflows: Use go 1.21.x for govuln tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck


### PR DESCRIPTION
go vuln doesn't support 1.20 anymore. It isn't required for tests to pass, so bump it to 1.21 even though we are still targeting 1.20, hopefully any errors it finds will be helpful in the future.

See:
* https://github.com/golang/go/issues/68034
* https://github.com/golang/vuln/commit/f35edf848bf0f2b9cf411833c60f72cc49915487