### PR TITLE
go.mod: Use go 1.21

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 20
           - 21
           - 22
     runs-on: ubuntu-latest
@@ -34,7 +33,6 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 20
           - 21
           - 22
     runs-on: ubuntu-latest
@@ -48,8 +46,8 @@ jobs:
       - name: Run unit tests on go 1.${{matrix.go}}.x
         run: make test
 
-      - name: Send coverage to codecov.io for go v1.19.x
-        if: matrix.go == 19
+      - name: Send coverage to codecov.io for go v1.21.x
+        if: matrix.go == 21
         run: bash <(curl -s https://codecov.io/bash)
 
   govulncheck:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/osbuild/weldr-client/v2
 
-go 1.20
+go 1.21
 
 require (
 	github.com/BurntSushi/toml v1.4.0

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION=1.20.12
+GO_VERSION=1.21.11
 GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 
 # this is the official way to get a different version of golang


### PR DESCRIPTION
We no longer need to support 1.20, switch to 1.21 and update the github workflow and prepare-source.sh script. Drop 1.20 from the test matrix.