### PR TITLE
README.md: align with image-builder-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 `composer-cli` is a command line utility used with
 [osbuild-composer](https://www.osbuild.org) to manage blueprints, build and
-upload images, and manage source repositories.
+upload images, and manage source repositories.  
+A (newer) alternative to `composer-cli` is [image-builder](https://github.com/osbuild/image-builder-cli),
+which works without a local systemd service setup.
 
 ## Project
 


### PR DESCRIPTION
Both projects are command line interfaces to
building images, it should be explained what the
difference is.

As soon as https://github.com/osbuild/osbuild.github.io/pull/151 lands, 
the projects are documented next to each other here https://osbuild.org/docs/developer-guide/projects/
so the difference between those two should be explained.
