### PR TITLE
New release: 36.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DESTDIR ?= /
-VERSION ?= 35.14
+VERSION ?= 36.0
 TAG = v$(VERSION)
 PREVTAG := $(shell git tag --sort=-creatordate | head -n 2 | tail -n 1)
 COMMITS := $(shell git log --pretty=oneline --no-merges ${PREVTAG}..HEAD | wc -l)


### PR DESCRIPTION
New release that includes support for using the cloudapi or the weldrapi.

DO NOT merge this using the github UI -- that will invalidate the gpg signature on the tag.

https://github.com/osbuild/osbuild-composer/pull/4811 needs to be merged first so that osbuild-composer tests will work with this new version's json output changes.