### PR TITLE
tests: Skip checking arch when testing sent body

### DIFF
--- a/cmd/composer-cli/projects/info_test.go
+++ b/cmd/composer-cli/projects/info_test.go
@@ -457,7 +457,9 @@ func TestCmdProjectsInfoCloud(t *testing.T) {
 	sentBody, err := io.ReadAll(mcc.Req.Body)
 	assert.Nil(t, mcc.Req.Body.Close())
 	require.Nil(t, err)
-	assert.Contains(t, string(sentBody), `{"distribution":"homer","architecture":"x86_64","packages":["tmux"]}`)
+	// NOTE: sentBody also contains arch specific architecture, skip checking that.
+	assert.Contains(t, string(sentBody), `"distribution":"homer"`)
+	assert.Contains(t, string(sentBody), `"packages":["tmux"]`)
 	assert.Equal(t, "application/json", mcc.Req.Header.Get("Content-Type"))
 	assert.Equal(t, "/api/image-builder-composer/v2/search/packages", mcc.Req.URL.Path)
 }

--- a/cmd/composer-cli/projects/list_test.go
+++ b/cmd/composer-cli/projects/list_test.go
@@ -363,7 +363,9 @@ func TestCmdProjectsListCloud(t *testing.T) {
 	sentBody, err := io.ReadAll(mcc.Req.Body)
 	assert.Nil(t, mcc.Req.Body.Close())
 	require.Nil(t, err)
-	assert.Contains(t, string(sentBody), `{"distribution":"homer","architecture":"x86_64","packages":["*"]}`)
+	// NOTE: sentBody also contains arch specific architecture, skip checking that.
+	assert.Contains(t, string(sentBody), `"distribution":"homer"`)
+	assert.Contains(t, string(sentBody), `"packages":["*"]`)
 	assert.Equal(t, "application/json", mcc.Req.Header.Get("Content-Type"))
 	assert.Equal(t, "/api/image-builder-composer/v2/search/packages", mcc.Req.URL.Path)
 }


### PR DESCRIPTION
The host architecture is included in the body of the request, skip checking for the specific arch in order to keep the tests architecture independent.

Related: RHEL-60137