### PR TITLE
Fix up tests for osbuild-composer 152

### DIFF
--- a/weldr/compose_test.go
+++ b/weldr/compose_test.go
@@ -93,7 +93,7 @@ aws_secret_key = "AWS Secret Key"
 
 // parentid with no url should result in an error
 func TestStartOSTreeParentNoURL(t *testing.T) {
-	_, r, err := testState.client.StartOSTreeComposeTest("cli-test-bp-1", "iot-qcow2-image", "refid", "parent", "", 0, 2)
+	_, r, err := testState.client.StartOSTreeComposeTest("cli-test-bp-4", "iot-qcow2-image", "refid", "parent", "", 0, 2)
 	require.Nil(t, err)
 	require.NotNil(t, r)
 	assert.False(t, r.Status)
@@ -101,7 +101,7 @@ func TestStartOSTreeParentNoURL(t *testing.T) {
 }
 
 func TestStartOSTreeComposeUrl(t *testing.T) {
-	id, r, err := testState.client.StartOSTreeComposeTest("cli-test-bp-1", "iot-qcow2-image", "refid", "", "http://weldr.io", 0, 2)
+	id, r, err := testState.client.StartOSTreeComposeTest("cli-test-bp-4", "iot-qcow2-image", "refid", "", "http://weldr.io", 0, 2)
 	require.Nil(t, err)
 	require.Nil(t, r)
 	assert.Greater(t, len(id), 0)
@@ -109,7 +109,7 @@ func TestStartOSTreeComposeUrl(t *testing.T) {
 
 func TestStartOSTreeParentAndUrl(t *testing.T) {
 	// Sending both the parent url and the parent id is now allowed
-	id, r, err := testState.client.StartOSTreeComposeTest("cli-test-bp-1", "iot-qcow2-image", "refid", "parent", "http://weldr.io", 0, 2)
+	id, r, err := testState.client.StartOSTreeComposeTest("cli-test-bp-4", "iot-qcow2-image", "refid", "parent", "http://weldr.io", 0, 2)
 	require.Nil(t, err)
 	require.Nil(t, r)
 	assert.Greater(t, len(id), 0)
@@ -130,7 +130,7 @@ aws_secret_key = "AWS Secret Key"
 `))
 	require.Nil(t, err)
 
-	id, r, err := testState.client.StartOSTreeComposeTestUpload("cli-test-bp-1", "iot-qcow2-image", "test-image", tmpProfile.Name(), "refid", "", "http://weldr.io", 0, 2)
+	id, r, err := testState.client.StartOSTreeComposeTestUpload("cli-test-bp-4", "iot-qcow2-image", "test-image", tmpProfile.Name(), "refid", "", "http://weldr.io", 0, 2)
 	require.Nil(t, err)
 	require.Nil(t, r)
 	assert.Greater(t, len(id), 0)

--- a/weldr/integration_test.go
+++ b/weldr/integration_test.go
@@ -47,6 +47,7 @@ func executeTests(m *testing.M) int {
 	testState.client.DeleteBlueprint("cli-test-bp-1") //nolint:errcheck
 	testState.client.DeleteBlueprint("cli-test-bp-2") //nolint:errcheck
 	testState.client.DeleteBlueprint("cli-test-bp-3") //nolint:errcheck
+	testState.client.DeleteBlueprint("cli-test-bp-4") //nolint:errcheck
 
 	// TODO Delete any existing test sources
 
@@ -139,6 +140,25 @@ func executeTests(m *testing.M) int {
 		name="tmux"
 		version="0"
 		`
+	resp, err = testState.client.PushBlueprintTOML(bp)
+	if err != nil {
+		panic(err)
+	}
+	if resp == nil {
+		panic(errors.New("No response for PushBlueprintTOML"))
+	}
+
+	// Push test blueprint for iot with no packages
+	bp = `
+		name="cli-test-bp-4"
+		description="composer-cli blueprint test 4"
+		version="0.0.1"
+
+		[[customizations.user]]
+		name="root"
+		password="qweqweqwe"
+		`
+	//nolint:errcheck
 	resp, err = testState.client.PushBlueprintTOML(bp)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
* qcow2 is now called server-qcows
* blueprint fields are now validated

Should fix the failures seen in https://artifacts.dev.testing-farm.io/103be063-9693-445d-8503-49527bd9d15b/